### PR TITLE
fix: allow queries without destination

### DIFF
--- a/src/routing/query.ts
+++ b/src/routing/query.ts
@@ -23,7 +23,7 @@ export class Query {
 
   static Builder = class {
     fromValue!: StopId;
-    toValue!: StopId[];
+    toValue: StopId[] = [];
     departureTimeValue!: Time;
     // lastDepartureTimeValue?: Date;
     // via: StopId[] = [];


### PR DESCRIPTION
Allowing queries without destination is useful for some use-cases, e.g. computing arrivals in the whole network to generate isochrone maps.