### PR TITLE
fix: include time lower bound when looking for earliest trip

### DIFF
--- a/src/timetable/timetable.ts
+++ b/src/timetable/timetable.ts
@@ -251,7 +251,7 @@ export class Timetable {
         const stopTimeIndex = tripIndex * stopsNumber + stopIndex;
         const stopTime = route.stopTimes[stopTimeIndex]!;
         if (
-          stopTime.departure > after &&
+          stopTime.departure >= after &&
           stopTime.pickUpType !== 'NOT_AVAILABLE'
         ) {
           return tripIndex;
@@ -268,7 +268,7 @@ export class Timetable {
       ) {
         const stopTimeIndex = tripIndex * stopsNumber + stopIndex;
         const stopTime = route.stopTimes[stopTimeIndex]!;
-        if (stopTime.departure <= after) {
+        if (stopTime.departure < after) {
           break;
         }
         if (


### PR DESCRIPTION
E.g. allow to take the train at 8:54 when connection arrives at 8:50 with 4 minutes transfers.