### PR TITLE
fix: do not pin point lib version for the repl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "kdbush": "^4.0.2",
         "loglevel": "^1.9.2",
         "luxon": "^3.5.0",
-        "minotor": "^1.0.7",
         "node-stream-zip": "^1.15.0",
         "slimsearch": "^2.2.1"
       },
@@ -6975,30 +6974,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minotor": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/minotor/-/minotor-1.0.7.tgz",
-      "integrity": "sha512-RMFtAeAAL6xYY4YzF509X6rt330DYH4ExY/wQ3CwklnWed64i2yAEDXEuzWNIikNlDVzTlOCti7rHSQnmf4ocQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.2.2",
-        "commander": "^12.1.0",
-        "csv-parse": "^5.5.6",
-        "geokdbush": "^2.0.1",
-        "kdbush": "^4.0.2",
-        "loglevel": "^1.9.2",
-        "luxon": "^3.5.0",
-        "node-stream-zip": "^1.15.0",
-        "slimsearch": "^2.2.1"
-      },
-      "bin": {
-        "minotor": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=21.1.0",
-        "npm": ">=10.9.1"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "kdbush": "^4.0.2",
     "loglevel": "^1.9.2",
     "luxon": "^3.5.0",
-    "minotor": "^1.0.7",
     "node-stream-zip": "^1.15.0",
     "slimsearch": "^2.2.1"
   }


### PR DESCRIPTION
Pinning the library version for the repl is not a desirable thing as it prevents from using the models exported with this same lib version.