### PR TITLE
feat: support for guaranteed transfers and default transfer time

### DIFF
--- a/src/gtfs/parser.ts
+++ b/src/gtfs/parser.ts
@@ -10,6 +10,7 @@ import { indexRoutes, parseRoutes } from './routes.js';
 import { parseCalendar, parseCalendarDates, ServiceIds } from './services.js';
 import { parseStops } from './stops.js';
 import {
+  GuaranteedTripTransfersMap,
   parseTransfers,
   TransfersMap,
   TripContinuationsMap,
@@ -113,6 +114,7 @@ export class GtfsParser {
 
     let transfers = new Map() as TransfersMap;
     let tripContinuations = new Map() as TripContinuationsMap;
+    let guaranteedTripTransfers = new Map() as GuaranteedTripTransfersMap;
     if (entries[TRANSFERS_FILE]) {
       log.info(`Parsing ${TRANSFERS_FILE}`);
       const transfersStart = performance.now();
@@ -120,12 +122,14 @@ export class GtfsParser {
       const {
         transfers: parsedTransfers,
         tripContinuations: parsedTripContinuations,
+        guaranteedTripTransfers: parsedGuaranteedTripTransfers,
       } = await parseTransfers(transfersStream, parsedStops);
       transfers = parsedTransfers;
       tripContinuations = parsedTripContinuations;
+      guaranteedTripTransfers = parsedGuaranteedTripTransfers;
       const transfersEnd = performance.now();
       log.info(
-        `${transfers.size} valid transfers and ${tripContinuations.size} trip continuations. (${(transfersEnd - transfersStart).toFixed(2)}ms)`,
+        `${transfers.size} valid transfers, ${tripContinuations.size} stops with trip continuations, and ${guaranteedTripTransfers.size} stops with guaranteed trip transfers. (${(transfersEnd - transfersStart).toFixed(2)}ms)`,
       );
     }
 
@@ -151,6 +155,7 @@ export class GtfsParser {
       routes,
       transfers,
       tripContinuations,
+      guaranteedTripTransfers,
       parsedStops.size,
       activeStopIds,
     );

--- a/src/gtfs/transfers.ts
+++ b/src/gtfs/transfers.ts
@@ -25,7 +25,14 @@ export type GtfsTripBoarding = {
   hopOnStop: StopId;
 };
 
+export type GuaranteedTripTransfer = {
+  fromTrip: GtfsTripId;
+  toTrip: GtfsTripId;
+};
+
 export type TripContinuationsMap = Map<StopId, GtfsTripBoarding[]>;
+
+export type GuaranteedTripTransfersMap = Map<StopId, GuaranteedTripTransfer[]>;
 
 export type TransferEntry = {
   from_stop_id?: SourceStopId;
@@ -50,9 +57,12 @@ export const parseTransfers = async (
 ): Promise<{
   transfers: TransfersMap;
   tripContinuations: TripContinuationsMap;
+  guaranteedTripTransfers: GuaranteedTripTransfersMap;
 }> => {
   const transfers: TransfersMap = new Map();
   const tripContinuations: TripContinuationsMap = new Map();
+  const guaranteedTripTransfers: GuaranteedTripTransfersMap = new Map();
+
   for await (const rawLine of parseCsv(transfersStream, [
     'transfer_type',
     'min_transfer_time',
@@ -65,7 +75,12 @@ export const parseTransfers = async (
     ) {
       continue;
     }
-    if (!transferEntry.from_stop_id || !transferEntry.to_stop_id) {
+    if (
+      transferEntry.from_stop_id === undefined ||
+      transferEntry.from_stop_id === '' ||
+      transferEntry.to_stop_id === undefined ||
+      transferEntry.to_stop_id === ''
+    ) {
       console.warn(`Missing transfer origin or destination stop.`);
       continue;
     }
@@ -75,68 +90,162 @@ export const parseTransfers = async (
     const toStop = stopsMap.get(transferEntry.to_stop_id)!;
 
     if (transferEntry.transfer_type === 4) {
-      if (
-        transferEntry.from_trip_id === undefined ||
-        transferEntry.from_trip_id === '' ||
-        transferEntry.to_trip_id === undefined ||
-        transferEntry.to_trip_id === ''
-      ) {
-        console.warn(
-          `Unsupported in-seat transfer, missing from_trip_id and/or to_trip_id.`,
-        );
-        continue;
-      }
-      const tripBoardingEntry: GtfsTripBoarding = {
-        fromTrip: transferEntry.from_trip_id,
-        toTrip: transferEntry.to_trip_id,
-        hopOnStop: toStop.id,
-      };
-      const existingBoardings = tripContinuations.get(fromStop.id);
-      if (existingBoardings) {
-        existingBoardings.push(tripBoardingEntry);
-      } else {
-        tripContinuations.set(fromStop.id, [tripBoardingEntry]);
-      }
-      continue;
-    }
-    if (transferEntry.from_trip_id && transferEntry.to_trip_id) {
-      console.warn(
-        `Unsupported transfer of type ${transferEntry.transfer_type} between trips ${transferEntry.from_trip_id} and ${transferEntry.to_trip_id}.`,
-      );
-      continue;
-    }
-    if (transferEntry.from_route_id && transferEntry.to_route_id) {
-      console.warn(
-        `Unsupported transfer of type ${transferEntry.transfer_type} between routes ${transferEntry.from_route_id} and ${transferEntry.to_route_id}.`,
+      processInSeatTransfer(
+        transferEntry,
+        fromStop.id,
+        toStop.id,
+        tripContinuations,
       );
       continue;
     }
 
-    if (
-      transferEntry.transfer_type === 2 &&
-      transferEntry.min_transfer_time === undefined
-    ) {
-      console.info(
-        `Missing minimum transfer time between ${transferEntry.from_stop_id} and ${transferEntry.to_stop_id}.`,
+    if (transferEntry.transfer_type === 1) {
+      processGuaranteedTransfer(
+        transferEntry,
+        fromStop.id,
+        guaranteedTripTransfers,
       );
+      continue;
     }
 
-    const transfer: Transfer = {
-      destination: toStop.id,
-      type: parseGtfsTransferType(transferEntry.transfer_type),
-      ...(transferEntry.min_transfer_time && {
-        minTransferTime: Duration.fromSeconds(transferEntry.min_transfer_time),
-      }),
-    };
-
-    const fromStopTransfers = transfers.get(fromStop.id) || [];
-    fromStopTransfers.push(transfer);
-    transfers.set(fromStop.id, fromStopTransfers);
+    const processed = processStandardTransfer(
+      transferEntry,
+      fromStop.id,
+      toStop.id,
+      transfers,
+    );
+    if (!processed) {
+      continue;
+    }
   }
+
   return {
     transfers,
     tripContinuations,
+    guaranteedTripTransfers,
   };
+};
+
+/**
+ * Processes an in-seat transfer (transfer_type = 4)
+ */
+const processInSeatTransfer = (
+  transferEntry: TransferEntry,
+  fromStopId: StopId,
+  toStopId: StopId,
+  tripContinuations: TripContinuationsMap,
+): void => {
+  if (
+    transferEntry.from_trip_id === undefined ||
+    transferEntry.from_trip_id === '' ||
+    transferEntry.to_trip_id === undefined ||
+    transferEntry.to_trip_id === ''
+  ) {
+    console.warn(
+      `Unsupported in-seat transfer, missing from_trip_id and/or to_trip_id.`,
+    );
+    return;
+  }
+
+  const tripBoardingEntry: GtfsTripBoarding = {
+    fromTrip: transferEntry.from_trip_id,
+    toTrip: transferEntry.to_trip_id,
+    hopOnStop: toStopId,
+  };
+
+  const existingBoardings = tripContinuations.get(fromStopId);
+  if (existingBoardings) {
+    existingBoardings.push(tripBoardingEntry);
+  } else {
+    tripContinuations.set(fromStopId, [tripBoardingEntry]);
+  }
+};
+
+/**
+ * Processes a guaranteed transfer (transfer_type = 1)
+ */
+const processGuaranteedTransfer = (
+  transferEntry: TransferEntry,
+  fromStopId: StopId,
+  guaranteedTripTransfers: GuaranteedTripTransfersMap,
+): void => {
+  if (
+    transferEntry.from_trip_id === undefined ||
+    transferEntry.from_trip_id === '' ||
+    transferEntry.to_trip_id === undefined ||
+    transferEntry.to_trip_id === ''
+  ) {
+    console.warn(
+      `Unsupported guaranteed transfer, missing from_trip_id and/or to_trip_id.`,
+    );
+    return;
+  }
+
+  if (transferEntry.from_stop_id !== transferEntry.to_stop_id) {
+    console.warn(
+      `Unsupported guaranteed transfer, from_stop and to_stop must match.`,
+    );
+    return;
+  }
+
+  const tripTransferEntry: GuaranteedTripTransfer = {
+    fromTrip: transferEntry.from_trip_id,
+    toTrip: transferEntry.to_trip_id,
+  };
+
+  const existingTransfers = guaranteedTripTransfers.get(fromStopId);
+  if (existingTransfers) {
+    existingTransfers.push(tripTransferEntry);
+  } else {
+    guaranteedTripTransfers.set(fromStopId, [tripTransferEntry]);
+  }
+};
+
+/**
+ * Processes standard transfers (transfer_type = 0 or 2)
+ */
+const processStandardTransfer = (
+  transferEntry: TransferEntry,
+  fromStopId: StopId,
+  toStopId: StopId,
+  transfers: TransfersMap,
+): boolean => {
+  if (transferEntry.from_trip_id || transferEntry.to_trip_id) {
+    console.warn(
+      `Unsupported transfer of type ${transferEntry.transfer_type} between trips ${transferEntry.from_trip_id ?? 'Unknown'} and ${transferEntry.to_trip_id ?? 'Unknown'}.`,
+    );
+    return false;
+  }
+
+  if (transferEntry.from_route_id || transferEntry.to_route_id) {
+    console.warn(
+      `Unsupported transfer of type ${transferEntry.transfer_type} between routes ${transferEntry.from_route_id ?? 'Unknown'} and ${transferEntry.to_route_id ?? 'Unknown'}.`,
+    );
+    return false;
+  }
+
+  if (
+    transferEntry.transfer_type === 2 &&
+    transferEntry.min_transfer_time === undefined
+  ) {
+    console.info(
+      `Missing minimum transfer time between ${transferEntry.from_stop_id} and ${transferEntry.to_stop_id}.`,
+    );
+  }
+
+  const transfer: Transfer = {
+    destination: toStopId,
+    type: parseGtfsTransferType(transferEntry.transfer_type),
+    ...(transferEntry.min_transfer_time && {
+      minTransferTime: Duration.fromSeconds(transferEntry.min_transfer_time),
+    }),
+  };
+
+  const fromStopTransfers = transfers.get(fromStopId) || [];
+  fromStopTransfers.push(transfer);
+  transfers.set(fromStopId, fromStopTransfers);
+
+  return true;
 };
 
 const parseGtfsTransferType = (

--- a/src/routing/query.ts
+++ b/src/routing/query.ts
@@ -3,16 +3,18 @@ import { Duration } from '../timetable/duration.js';
 import { Time } from '../timetable/time.js';
 import { ALL_TRANSPORT_MODES, RouteType } from '../timetable/timetable.js';
 
+export type QueryOptions = {
+  maxTransfers: number;
+  minTransferTime: Duration;
+  transportModes: Set<RouteType>;
+};
+
 export class Query {
   from: SourceStopId;
   to: Set<SourceStopId>;
   departureTime: Time;
   lastDepartureTime?: Time;
-  options: {
-    maxTransfers: number;
-    minTransferTime: Duration;
-    transportModes: Set<RouteType>;
-  };
+  options: QueryOptions;
 
   constructor(builder: typeof Query.Builder.prototype) {
     this.from = builder.fromValue;

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -62,7 +62,7 @@ export class Route {
    * @throws If no vehicle leg is found in the route.
    */
   departureTime(): Time {
-    const cumulativeTransferTime: Duration = Duration.zero();
+    const cumulativeTransferTime: Duration = Duration.ZERO;
     for (let i = 0; i < this.legs.length; i++) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const leg = this.legs[i]!;
@@ -83,8 +83,8 @@ export class Route {
    * @throws If no vehicle leg is found in the route.
    */
   arrivalTime(): Time {
-    let lastVehicleArrivalTime: Time = Time.origin();
-    const totalTransferTime: Duration = Duration.zero();
+    let lastVehicleArrivalTime: Time = Time.ORIGIN;
+    const totalTransferTime: Duration = Duration.ZERO;
     let vehicleLegFound = false;
 
     for (let i = this.legs.length - 1; i >= 0; i--) {
@@ -116,7 +116,7 @@ export class Route {
    * @returns The total duration of the route.
    */
   totalDuration(): Duration {
-    if (this.legs.length === 0) return Duration.zero();
+    if (this.legs.length === 0) return Duration.ZERO;
     return this.arrivalTime().diff(this.departureTime());
   }
 

--- a/src/timetable/__tests__/route.test.ts
+++ b/src/timetable/__tests__/route.test.ts
@@ -292,7 +292,7 @@ describe('Route', () => {
     });
 
     it('should return undefined when beforeTrip is 0', () => {
-      const tripIndex = route.findEarliestTrip(1001, Time.origin(), 0);
+      const tripIndex = route.findEarliestTrip(1001, Time.ORIGIN, 0);
       assert.strictEqual(tripIndex, undefined);
     });
 

--- a/src/timetable/__tests__/time.test.ts
+++ b/src/timetable/__tests__/time.test.ts
@@ -8,20 +8,20 @@ describe('Time', () => {
   describe('Static factory methods', () => {
     describe('infinity()', () => {
       it('should return a Time instance representing infinity', () => {
-        const infinityTime = Time.infinity();
+        const infinityTime = Time.INFINITY;
         assert.strictEqual(infinityTime.toMinutes(), Number.MAX_SAFE_INTEGER);
       });
 
       it('should return the same infinity value for multiple calls', () => {
-        const infinity1 = Time.infinity();
-        const infinity2 = Time.infinity();
+        const infinity1 = Time.INFINITY;
+        const infinity2 = Time.INFINITY;
         assert(infinity1.equals(infinity2));
       });
     });
 
     describe('origin()', () => {
       it('should return a Time instance representing midnight (0 minutes)', () => {
-        const midnight = Time.origin();
+        const midnight = Time.ORIGIN;
         assert.strictEqual(midnight.toMinutes(), 0);
         assert.strictEqual(midnight.toString(), '00:00');
       });
@@ -236,7 +236,7 @@ describe('Time', () => {
       });
 
       it('should return 0 for midnight', () => {
-        const time = Time.origin();
+        const time = Time.ORIGIN;
         assert.strictEqual(time.toMinutes(), 0);
       });
     });
@@ -411,7 +411,7 @@ describe('Time', () => {
 
       it('should handle infinity time', () => {
         const time1 = Time.fromMinutes(120);
-        const infinity = Time.infinity();
+        const infinity = Time.INFINITY;
         const maxTime = Time.max(time1, infinity);
         assert.strictEqual(maxTime, infinity);
       });
@@ -448,7 +448,7 @@ describe('Time', () => {
 
       it('should handle origin time', () => {
         const time1 = Time.fromMinutes(120);
-        const origin = Time.origin();
+        const origin = Time.ORIGIN;
         const minTime = Time.min(time1, origin);
         assert.strictEqual(minTime, origin);
       });
@@ -484,7 +484,7 @@ describe('Time', () => {
 
     it('should handle comparison with infinity', () => {
       const normalTime = Time.fromMinutes(1000);
-      const infinity = Time.infinity();
+      const infinity = Time.INFINITY;
 
       assert.strictEqual(normalTime.isBefore(infinity), true);
       assert.strictEqual(infinity.isAfter(normalTime), true);

--- a/src/timetable/duration.ts
+++ b/src/timetable/duration.ts
@@ -1,5 +1,6 @@
 export class Duration {
   private totalSeconds: number;
+  public static ZERO = new Duration(0);
 
   private constructor(totalSeconds: number) {
     this.totalSeconds = totalSeconds;
@@ -21,14 +22,6 @@ export class Duration {
    */
   static fromMinutes(minutes: number): Duration {
     return new Duration(minutes * 60);
-  }
-  /**
-   * Gets a Duration instance representing zero duration (0 hours, 0 minutes, 0 seconds).
-   *
-   * @returns A Duration instance representing zero duration.
-   */
-  static zero(): Duration {
-    return new Duration(0);
   }
 
   /**

--- a/src/timetable/proto/timetable.proto
+++ b/src/timetable/proto/timetable.proto
@@ -47,14 +47,20 @@ message TripBoarding {
 }
 
 message TripContinuationEntry {
-  uint32 key = 1;
-  repeated TripBoarding value = 2;
+  uint32 fromTripId = 1;
+  repeated TripBoarding boardings = 2;
+}
+
+message GuaranteedTripTransferEntry {
+  uint32 fromTripId = 1;
+  repeated uint32 guaranteedTripIds = 2;
 }
 
 message StopAdjacency {
   repeated uint32 routes = 1;
   repeated Transfer transfers = 2;
   repeated TripContinuationEntry tripContinuations = 3;
+  repeated GuaranteedTripTransferEntry guaranteedTripTransfers = 4;
 }
 
 enum RouteType {

--- a/src/timetable/route.ts
+++ b/src/timetable/route.ts
@@ -401,7 +401,7 @@ export class Route {
    */
   findEarliestTrip(
     stopId: StopId,
-    after: Time = Time.origin(),
+    after: Time = Time.ORIGIN,
     beforeTrip?: TripRouteIndex,
   ): TripRouteIndex | undefined {
     if (this.nbTrips <= 0) return undefined;
@@ -415,6 +415,7 @@ export class Route {
     while (lo <= hi) {
       const mid = (lo + hi) >>> 1;
       const depMid = this.departureFrom(stopId, mid);
+
       if (depMid.isBefore(after)) {
         lo = mid + 1;
       } else {
@@ -423,14 +424,7 @@ export class Route {
       }
     }
     if (lb === -1) return undefined;
-
-    for (let t = lb; t < (beforeTrip ?? this.nbTrips); t++) {
-      const pickup = this.pickUpTypeFrom(stopId, t);
-      if (pickup !== 'NOT_AVAILABLE') {
-        return t;
-      }
-    }
-    return undefined;
+    return lb;
   }
 
   /**

--- a/src/timetable/time.ts
+++ b/src/timetable/time.ts
@@ -4,28 +4,13 @@ import { Duration } from './duration.js';
  * A class representing a time as minutes since midnight.
  */
 export class Time {
+  public static INFINITY = new Time(Number.MAX_SAFE_INTEGER);
+  public static ORIGIN = new Time(0);
   /*
    * Number of minutes since midnight.
    Note that this value can go beyond 3600 to model services overlapping with the next day.
    */
   private minutesSinceMidnight: number;
-  /**
-   * Gets the infinity time as a Time instance.
-   * This represents a time that is conceptually beyond any real possible time.
-   *
-   * @returns A Time instance representing an "infinity" time.
-   */
-  static infinity(): Time {
-    return new Time(Number.MAX_SAFE_INTEGER);
-  }
-  /**
-   * Gets the midnight time as a Time instance.
-   *
-   * @returns A Time instance representing midnight.
-   */
-  static origin(): Time {
-    return new Time(0);
-  }
 
   private constructor(minutes: number) {
     this.minutesSinceMidnight = minutes;

--- a/src/timetable/tripId.ts
+++ b/src/timetable/tripId.ts
@@ -7,6 +7,11 @@ const TRIP_INDEX_MASK = (1 << TRIP_INDEX_BITS) - 1;
 // A TripId encodes a route ID and trip index into a value
 export type TripId = number;
 
+export type Trip = {
+  routeId: RouteId;
+  tripIndex: TripRouteIndex;
+};
+
 /**
  * Encodes a route ID and trip index into a single trip ID.
  * @param routeId - The route identifier, needs to fit on 17 bits


### PR DESCRIPTION
DEPRECATED: #52 is the correct implementation

Parses GTFS type 4 guaranteed transfers (trip-to-trip only). Adjust the router to take guaranteed trip transfers into account during routing. Ensures that the default 2 minutes transfer time is applied in all cases.

BREAKING CHANGE: Timetable binary format updated and is not compatible with the previous one.

Fixes #33 and #36
