### PR TITLE
feat: guaranteed transfer support

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -51,7 +51,9 @@
     "dropoff",
     "boardable",
     "alightable",
-    "penwidth"
+    "penwidth",
+    "catchable",
+    "Tpng"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/src/__e2e__/timetable/stops.bin
+++ b/src/__e2e__/timetable/stops.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8147a3beb12e5dd65fe2bb5ed4013adaa0897ac84bd9722f53a7f38ebfaa9100
-size 4542160
+oid sha256:d30626d5434d63468a38730a390ae521433aa0a16af538a1a2bd12fbaafc5efd
+size 5168379

--- a/src/__e2e__/timetable/timetable.bin
+++ b/src/__e2e__/timetable/timetable.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f18f8795ee3dcb04accc3f372cde7041ec4c6d2812fee03e2a0c9de39d4149a6
-size 18441262
+oid sha256:cfef3cbdc98e8b76d8ac7bc35c37fe14ff6256276cd3f1bb7e04abd2046df600
+size 19297303

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -410,9 +410,7 @@ export const startRepl = (stopsPath: string, timetablePath: string) => {
                 totalContinuations++;
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const destRoute = timetable.getRoute(continuation.routeId)!;
-                const destStopId = destRoute.stopId(
-                  continuation.hopOnStopIndex,
-                );
+                const destStopId = destRoute.stopId(continuation.stopIndex);
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const destStop = stopsIndex.findStopById(destStopId)!;
                 const destPlatform = destStop.platform
@@ -424,7 +422,7 @@ export const startRepl = (stopsPath: string, timetablePath: string) => {
 
                 const originTime = route.departureFrom(stopIndex, tripIndex);
                 const continuationTime = destRoute.departureFrom(
-                  continuation.hopOnStopIndex,
+                  continuation.stopIndex,
                   continuation.tripIndex,
                 );
 
@@ -443,7 +441,51 @@ export const startRepl = (stopsPath: string, timetablePath: string) => {
         } else {
           console.log(`\nTotal trip continuations: ${totalContinuations}`);
         }
+        let totalGuaranteedTransfers = 0;
+        console.log('\n--- Guaranteed Trip Transfers ---');
+        routes.forEach((route: Route) => {
+          const serviceRouteInfo = timetable.getServiceRouteInfo(route);
+          const stopIndices = route.stopRouteIndices(stop.id);
 
+          for (let tripIndex = 0; tripIndex < route.getNbTrips(); tripIndex++) {
+            for (const stopIndex of stopIndices) {
+              const guaranteedTransfers = timetable.getGuaranteedTripTransfers(
+                stopIndex,
+                route.id,
+                tripIndex,
+              );
+
+              for (const guaranteedTrip of guaranteedTransfers) {
+                totalGuaranteedTransfers++;
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const destRoute = timetable.getRoute(guaranteedTrip.routeId)!;
+
+                const destServiceRouteInfo =
+                  timetable.getServiceRouteInfo(destRoute);
+
+                const originTime = route.arrivalAt(stopIndex, tripIndex);
+                const destinationTime = destRoute.departureFrom(
+                  guaranteedTrip.stopIndex,
+                  guaranteedTrip.tripIndex,
+                );
+
+                console.log(
+                  `${totalGuaranteedTransfers}. From Route ${route.id} (${serviceRouteInfo.name}) Trip ${tripIndex} at ${originTime.toString()} → ` +
+                    `Route ${guaranteedTrip.routeId} (${destServiceRouteInfo.name}) Trip ${guaranteedTrip.tripIndex} at ${destinationTime.toString()} `,
+                );
+                console.log(stopIndex, route.id, tripIndex);
+              }
+            }
+          }
+        });
+
+        if (totalGuaranteedTransfers === 0) {
+          console.log('No guaranteed trip transfers found.');
+        } else {
+          console.log(
+            `\nTotal guaranteed trip transfers: ${totalGuaranteedTransfers}`,
+          );
+        }
         console.log();
       };
 

--- a/src/gtfs/__tests__/transfers.test.ts
+++ b/src/gtfs/__tests__/transfers.test.ts
@@ -6,11 +6,11 @@ import { Duration } from '../../timetable/duration.js';
 import { Route } from '../../timetable/route.js';
 import { Time } from '../../timetable/time.js';
 import { Timetable } from '../../timetable/timetable.js';
-import { encode } from '../../timetable/tripBoardingId.js';
+import { encode } from '../../timetable/tripStopId.js';
 import { GtfsStopsMap } from '../stops.js';
 import {
-  buildTripContinuations,
-  GtfsTripContinuation,
+  buildTripTransfers,
+  GtfsTripTransfer,
   parseTransfers,
 } from '../transfers.js';
 import { TripsMapping } from '../trips.js';
@@ -264,6 +264,173 @@ describe('GTFS transfers parser', () => {
 
     assert.deepEqual(result.transfers, new Map());
     assert.deepEqual(result.tripContinuations, expectedTripContinuations);
+    assert.deepEqual(result.guaranteedTripTransfers, []);
+  });
+
+  it('should correctly parse guaranteed transfers (type 1) with trip IDs', async () => {
+    const mockedStream = new Readable();
+    mockedStream.push(
+      'from_stop_id,to_stop_id,from_trip_id,to_trip_id,transfer_type,min_transfer_time\n',
+    );
+    mockedStream.push('"1100084","8014440:0:1","tripA","tripB","1","0"\n');
+    mockedStream.push('"1100097","8014447","tripC","tripD","1","60"\n');
+    mockedStream.push(null);
+
+    const stopsMap: GtfsStopsMap = new Map([
+      [
+        '1100084',
+        {
+          id: 0,
+          sourceStopId: '1100084',
+          name: 'Test Stop 1',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+      [
+        '8014440:0:1',
+        {
+          id: 1,
+          sourceStopId: '8014440:0:1',
+          name: 'Test Stop 2',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+      [
+        '1100097',
+        {
+          id: 2,
+          sourceStopId: '1100097',
+          name: 'Test Stop 3',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+      [
+        '8014447',
+        {
+          id: 3,
+          sourceStopId: '8014447',
+          name: 'Test Stop 4',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+    ]);
+
+    const result = await parseTransfers(mockedStream, stopsMap);
+
+    const expectedGuaranteedTripTransfers = [
+      {
+        fromStop: 0,
+        fromTrip: 'tripA',
+        toStop: 1,
+        toTrip: 'tripB',
+      },
+      {
+        fromStop: 2,
+        fromTrip: 'tripC',
+        toStop: 3,
+        toTrip: 'tripD',
+      },
+    ];
+
+    // Guaranteed transfers with trip IDs should go to guaranteedTripTransfers, not transfers
+    assert.deepEqual(result.transfers, new Map());
+    assert.deepEqual(result.tripContinuations, []);
+    assert.deepEqual(
+      result.guaranteedTripTransfers,
+      expectedGuaranteedTripTransfers,
+    );
+  });
+
+  it('should differentiate guaranteed transfers with and without trip IDs', async () => {
+    const mockedStream = new Readable();
+    mockedStream.push(
+      'from_stop_id,to_stop_id,from_trip_id,to_trip_id,transfer_type,min_transfer_time\n',
+    );
+    // Type 1 with trip IDs -> goes to guaranteedTripTransfers
+    mockedStream.push('"1100084","8014440:0:1","tripA","tripB","1","0"\n');
+    // Type 1 without trip IDs -> goes to transfers as stop-to-stop
+    mockedStream.push('"1100097","8014447","","","1","120"\n');
+    mockedStream.push(null);
+
+    const stopsMap: GtfsStopsMap = new Map([
+      [
+        '1100084',
+        {
+          id: 0,
+          sourceStopId: '1100084',
+          name: 'Test Stop 1',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+      [
+        '8014440:0:1',
+        {
+          id: 1,
+          sourceStopId: '8014440:0:1',
+          name: 'Test Stop 2',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+      [
+        '1100097',
+        {
+          id: 2,
+          sourceStopId: '1100097',
+          name: 'Test Stop 3',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+      [
+        '8014447',
+        {
+          id: 3,
+          sourceStopId: '8014447',
+          name: 'Test Stop 4',
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ],
+    ]);
+
+    const result = await parseTransfers(mockedStream, stopsMap);
+
+    // Type 1 with trip IDs -> guaranteedTripTransfers
+    const expectedGuaranteedTripTransfers = [
+      {
+        fromStop: 0,
+        fromTrip: 'tripA',
+        toStop: 1,
+        toTrip: 'tripB',
+      },
+    ];
+
+    // Type 1 without trip IDs -> transfers (stop-to-stop)
+    const expectedTransfers = new Map([
+      [
+        2,
+        [
+          {
+            destination: 3,
+            type: 'GUARANTEED',
+            minTransferTime: Duration.fromSeconds(120),
+          },
+        ],
+      ],
+    ]);
+
+    assert.deepEqual(result.transfers, expectedTransfers);
+    assert.deepEqual(result.tripContinuations, []);
+    assert.deepEqual(
+      result.guaranteedTripTransfers,
+      expectedGuaranteedTripTransfers,
+    );
   });
 
   it('should ignore in-seat transfers with missing trip IDs', async () => {
@@ -628,14 +795,14 @@ describe('GTFS transfers parser', () => {
   });
 });
 
-describe('buildTripContinuations', () => {
-  it('should build trip continuations for valid data', () => {
+describe('buildTripTransfers', () => {
+  it('should build trip transfers for valid data', () => {
     const tripsMapping: TripsMapping = new Map([
       ['trip1', { routeId: 0, tripRouteIndex: 0 }],
       ['trip2', { routeId: 1, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100,
         fromTrip: 'trip1',
@@ -644,7 +811,6 @@ describe('buildTripContinuations', () => {
       },
     ];
 
-    // Mock route with simple stops and timing
     const mockFromRoute = {
       stopRouteIndices: () => [0],
       arrivalAt: () => Time.fromMinutes(60), // 1:00
@@ -662,32 +828,32 @@ describe('buildTripContinuations', () => {
 
     const activeStopIds = new Set([100, 200]);
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
 
     const expectedTripBoardingId = encode(0, 0, 0);
-    const continuations = result.get(expectedTripBoardingId);
+    const transfers = result.get(expectedTripBoardingId);
 
-    assert(continuations);
-    assert.strictEqual(continuations.length, 1);
-    assert.deepEqual(continuations[0], {
-      hopOnStopIndex: 1,
+    assert(transfers);
+    assert.strictEqual(transfers.length, 1);
+    assert.deepEqual(transfers[0], {
+      stopIndex: 1,
       routeId: 1,
       tripIndex: 0,
     });
   });
 
-  it('should ignore trip continuations with inactive stops', () => {
+  it('should ignore transfers with inactive stops', () => {
     const tripsMapping: TripsMapping = new Map([
       ['trip1', { routeId: 0, tripRouteIndex: 0 }],
       ['trip2', { routeId: 1, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100, // inactive stop
         fromTrip: 'trip1',
@@ -699,9 +865,9 @@ describe('buildTripContinuations', () => {
     const mockTimetable = {} as unknown as Timetable;
     const activeStopIds = new Set([200]); // only toStop is active
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
@@ -709,12 +875,12 @@ describe('buildTripContinuations', () => {
     assert.strictEqual(result.size, 0);
   });
 
-  it('should ignore trip continuations with unknown trip IDs', () => {
+  it('should ignore transfers with unknown trip IDs', () => {
     const tripsMapping: TripsMapping = new Map([
       ['trip1', { routeId: 0, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100,
         fromTrip: 'unknown_trip', // not in tripsMapping
@@ -726,9 +892,9 @@ describe('buildTripContinuations', () => {
     const mockTimetable = {} as unknown as Timetable;
     const activeStopIds = new Set([100, 200]);
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
@@ -736,13 +902,13 @@ describe('buildTripContinuations', () => {
     assert.strictEqual(result.size, 0);
   });
 
-  it('should ignore trip continuations with unknown routes', () => {
+  it('should ignore transfers with unknown routes', () => {
     const tripsMapping: TripsMapping = new Map([
       ['trip1', { routeId: 0, tripRouteIndex: 0 }],
       ['trip2', { routeId: 1, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100,
         fromTrip: 'trip1',
@@ -757,9 +923,9 @@ describe('buildTripContinuations', () => {
 
     const activeStopIds = new Set([100, 200]);
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
@@ -767,13 +933,13 @@ describe('buildTripContinuations', () => {
     assert.strictEqual(result.size, 0);
   });
 
-  it('should ignore trip continuations with no valid timing', () => {
+  it('should ignore transfers with no valid timing', () => {
     const tripsMapping: TripsMapping = new Map([
       ['trip1', { routeId: 0, tripRouteIndex: 0 }],
       ['trip2', { routeId: 1, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100,
         fromTrip: 'trip1',
@@ -799,9 +965,9 @@ describe('buildTripContinuations', () => {
 
     const activeStopIds = new Set([100, 200]);
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
@@ -809,14 +975,14 @@ describe('buildTripContinuations', () => {
     assert.strictEqual(result.size, 0);
   });
 
-  it('should handle multiple continuations from same trip boarding', () => {
+  it('should handle multiple transfers from same trip boarding', () => {
     const tripsMapping: TripsMapping = new Map([
       ['trip1', { routeId: 0, tripRouteIndex: 0 }],
       ['trip2', { routeId: 1, tripRouteIndex: 0 }],
       ['trip3', { routeId: 2, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100,
         fromTrip: 'trip1',
@@ -857,25 +1023,25 @@ describe('buildTripContinuations', () => {
 
     const activeStopIds = new Set([100, 200, 300]);
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
 
     const expectedTripBoardingId = encode(0, 0, 0);
-    const continuations = result.get(expectedTripBoardingId);
+    const transfers = result.get(expectedTripBoardingId);
 
-    assert(continuations);
-    assert.strictEqual(continuations.length, 2);
-    assert.deepEqual(continuations[0], {
-      hopOnStopIndex: 1,
+    assert(transfers);
+    assert.strictEqual(transfers.length, 2);
+    assert.deepEqual(transfers[0], {
+      stopIndex: 1,
       routeId: 1,
       tripIndex: 0,
     });
-    assert.deepEqual(continuations[1], {
-      hopOnStopIndex: 2,
+    assert.deepEqual(transfers[1], {
+      stopIndex: 2,
       routeId: 2,
       tripIndex: 0,
     });
@@ -883,13 +1049,13 @@ describe('buildTripContinuations', () => {
 
   it('should handle empty input gracefully', () => {
     const tripsMapping: TripsMapping = new Map();
-    const tripContinuations: GtfsTripContinuation[] = [];
+    const tripTransfers: GtfsTripTransfer[] = [];
     const mockTimetable = {} as unknown as Timetable;
     const activeStopIds = new Set<number>();
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
@@ -903,7 +1069,7 @@ describe('buildTripContinuations', () => {
       ['trip2', { routeId: 1, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100, // This stop appears multiple times in the route
         fromTrip: 'trip1',
@@ -937,9 +1103,9 @@ describe('buildTripContinuations', () => {
 
     const activeStopIds = new Set([100, 200]);
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
@@ -947,12 +1113,12 @@ describe('buildTripContinuations', () => {
     // Should pick the best timing: arrive at stop 0 (1:00) -> depart from stop 1 (1:10)
     // This is better than arrive at stop 3 (2:00) -> depart from stop 4 (2:30)
     const expectedTripBoardingId = encode(0, 0, 0); // stopIndex=0, routeId=0, tripIndex=0
-    const continuations = result.get(expectedTripBoardingId);
+    const transfers = result.get(expectedTripBoardingId);
 
-    assert(continuations);
-    assert.strictEqual(continuations.length, 1);
-    assert.deepEqual(continuations[0], {
-      hopOnStopIndex: 1, // Best to-stop index
+    assert(transfers);
+    assert.strictEqual(transfers.length, 1);
+    assert.deepEqual(transfers[0], {
+      stopIndex: 1, // Best to-stop index
       routeId: 1,
       tripIndex: 0,
     });
@@ -964,7 +1130,7 @@ describe('buildTripContinuations', () => {
       ['trip2', { routeId: 1, tripRouteIndex: 0 }],
     ]);
 
-    const tripContinuations = [
+    const tripTransfers: GtfsTripTransfer[] = [
       {
         fromStop: 100,
         fromTrip: 'trip1',
@@ -997,14 +1163,14 @@ describe('buildTripContinuations', () => {
 
     const activeStopIds = new Set([100, 200]);
 
-    const result = buildTripContinuations(
+    const result = buildTripTransfers(
       tripsMapping,
-      tripContinuations,
+      tripTransfers,
       mockTimetable,
       activeStopIds,
     );
 
-    // Should find no valid continuations since all departures are before arrivals
+    // Should find no valid transfers since all departures are before arrivals
     assert.strictEqual(result.size, 0);
   });
 });

--- a/src/gtfs/parser.ts
+++ b/src/gtfs/parser.ts
@@ -10,8 +10,8 @@ import { indexRoutes, parseRoutes } from './routes.js';
 import { parseCalendar, parseCalendarDates, ServiceIds } from './services.js';
 import { parseStops } from './stops.js';
 import {
-  buildTripContinuations,
-  GtfsTripContinuation,
+  buildTripTransfers,
+  GtfsTripTransfer,
   parseTransfers,
   TransfersMap,
 } from './transfers.js';
@@ -113,7 +113,8 @@ export class GtfsParser {
     );
 
     let transfers: TransfersMap = new Map();
-    let tripContinuationsMap: GtfsTripContinuation[] = [];
+    let tripContinuationsList: GtfsTripTransfer[] = [];
+    let guaranteedTripTransfersList: GtfsTripTransfer[] = [];
     if (entries[TRANSFERS_FILE]) {
       log.info(`Parsing ${TRANSFERS_FILE}`);
       const transfersStart = performance.now();
@@ -121,12 +122,14 @@ export class GtfsParser {
       const {
         transfers: parsedTransfers,
         tripContinuations: parsedTripContinuations,
+        guaranteedTripTransfers: parsedGuaranteedTripTransfers,
       } = await parseTransfers(transfersStream, parsedStops);
       transfers = parsedTransfers;
-      tripContinuationsMap = parsedTripContinuations;
+      tripContinuationsList = parsedTripContinuations;
+      guaranteedTripTransfersList = parsedGuaranteedTripTransfers;
       const transfersEnd = performance.now();
       log.info(
-        `${transfers.size} valid transfers and ${tripContinuationsMap.length} trip continuations. (${(transfersEnd - transfersStart).toFixed(2)}ms)`,
+        `${transfers.size} valid transfers and ${tripContinuationsList.length} trip continuations and ${guaranteedTripTransfersList.length} guaranteed trip transfers. (${(transfersEnd - transfersStart).toFixed(2)}ms)`,
       );
     }
 
@@ -165,9 +168,9 @@ export class GtfsParser {
 
     log.info('Building in-seat trip continuations');
     const tripContinuationsStart = performance.now();
-    const tripContinuations = buildTripContinuations(
+    const tripContinuations = buildTripTransfers(
       tripsMapping,
-      tripContinuationsMap,
+      tripContinuationsList,
       timetable,
       activeStopIds,
     );
@@ -176,12 +179,26 @@ export class GtfsParser {
       `${tripContinuations.size} in-seat trip continuations origins created. (${(tripContinuationsEnd - tripContinuationsStart).toFixed(2)}ms)`,
     );
     log.info('Parsing complete.');
+    log.info('Building guaranteed trip transfers');
+    const guaranteedTripTransfersStart = performance.now();
+    const guaranteedTripTransfers = buildTripTransfers(
+      tripsMapping,
+      guaranteedTripTransfersList,
+      timetable,
+      activeStopIds,
+    );
+    const guaranteedTripTransfersEnd = performance.now();
+    log.info(
+      `${guaranteedTripTransfers.size} guaranteed trip transfers origins created. (${(guaranteedTripTransfersEnd - guaranteedTripTransfersStart).toFixed(2)}ms)`,
+    );
+    log.info('Parsing complete.');
 
     return new Timetable(
       stopsAdjacency,
       routes,
       serviceRoutes,
       tripContinuations,
+      guaranteedTripTransfers,
     );
   }
 

--- a/src/gtfs/transfers.ts
+++ b/src/gtfs/transfers.ts
@@ -6,10 +6,10 @@ import {
   Timetable,
   Transfer,
   TransferType,
-  TripBoarding,
-  TripContinuations,
+  TripStop,
+  TripTransfers as TripTransfers,
 } from '../timetable/timetable.js';
-import { encode } from '../timetable/tripBoardingId.js';
+import { encode } from '../timetable/tripStopId.js';
 import { GtfsStopsMap } from './stops.js';
 import { GtfsTripId, TripsMapping } from './trips.js';
 import { parseCsv } from './utils.js';
@@ -24,7 +24,7 @@ export type GtfsTransferType =
 
 export type TransfersMap = Map<StopId, Transfer[]>;
 
-export type GtfsTripContinuation = {
+export type GtfsTripTransfer = {
   fromStop: StopId;
   fromTrip: GtfsTripId;
   toStop: StopId;
@@ -43,6 +43,138 @@ export type TransferEntry = {
 };
 
 /**
+ * Processes in-seat transfer entries (type 4).
+ */
+const processInSeatTransfer = (
+  transferEntry: TransferEntry,
+  fromStop: StopId,
+  toStop: StopId,
+  tripContinuations: GtfsTripTransfer[],
+): void => {
+  if (
+    transferEntry.from_trip_id === undefined ||
+    transferEntry.from_trip_id === '' ||
+    transferEntry.to_trip_id === undefined ||
+    transferEntry.to_trip_id === ''
+  ) {
+    console.warn(
+      `Unsupported in-seat transfer, missing from_trip_id and/or to_trip_id.`,
+    );
+    return;
+  }
+
+  const tripContinuationEntry: GtfsTripTransfer = {
+    fromStop,
+    fromTrip: transferEntry.from_trip_id,
+    toStop,
+    toTrip: transferEntry.to_trip_id,
+  };
+  tripContinuations.push(tripContinuationEntry);
+};
+
+/**
+ * Processes guaranteed transfer entries (type 1) with trip IDs as trip-to-trip transfers.
+ */
+const processGuaranteedTripTransfer = (
+  transferEntry: TransferEntry,
+  fromStop: StopId,
+  toStop: StopId,
+  guaranteedTripTransfers: GtfsTripTransfer[],
+): void => {
+  if (
+    transferEntry.from_trip_id === undefined ||
+    transferEntry.from_trip_id === '' ||
+    transferEntry.to_trip_id === undefined ||
+    transferEntry.to_trip_id === ''
+  ) {
+    // This shouldn't be called without trip IDs
+    return;
+  }
+
+  const guaranteedTripTransferEntry: GtfsTripTransfer = {
+    fromStop,
+    fromTrip: transferEntry.from_trip_id,
+    toStop,
+    toTrip: transferEntry.to_trip_id,
+  };
+  guaranteedTripTransfers.push(guaranteedTripTransferEntry);
+};
+
+/**
+ * Processes guaranteed transfer entries (type 1) without trip IDs as stop-to-stop transfers.
+ */
+const processGuaranteedStopTransfer = (
+  transferEntry: TransferEntry,
+  fromStop: StopId,
+  toStop: StopId,
+  transfers: TransfersMap,
+): void => {
+  // Reject transfers that specify route IDs - these are not supported for stop-to-stop transfers
+  if (transferEntry.from_route_id || transferEntry.to_route_id) {
+    console.warn(
+      `Unsupported transfer of type ${transferEntry.transfer_type} between routes ${transferEntry.from_route_id} and ${transferEntry.to_route_id}.`,
+    );
+    return;
+  }
+
+  const transfer: Transfer = {
+    destination: toStop,
+    type: 'GUARANTEED',
+    ...(transferEntry.min_transfer_time !== undefined && {
+      minTransferTime: Duration.fromSeconds(transferEntry.min_transfer_time),
+    }),
+  };
+
+  const fromStopTransfers = transfers.get(fromStop) || [];
+  fromStopTransfers.push(transfer);
+  transfers.set(fromStop, fromStopTransfers);
+};
+
+/**
+ * Processes regular stop-to-stop transfer entries (types 0 and 2).
+ */
+const processStopToStopTransfer = (
+  transferEntry: TransferEntry,
+  fromStop: StopId,
+  toStop: StopId,
+  transfers: TransfersMap,
+): void => {
+  if (transferEntry.from_trip_id || transferEntry.to_trip_id) {
+    console.warn(
+      `Unsupported transfer of type ${transferEntry.transfer_type} between trips ${transferEntry.from_trip_id} and ${transferEntry.to_trip_id}.`,
+    );
+    return;
+  }
+  if (transferEntry.from_route_id || transferEntry.to_route_id) {
+    console.warn(
+      `Unsupported transfer of type ${transferEntry.transfer_type} between routes ${transferEntry.from_route_id} and ${transferEntry.to_route_id}.`,
+    );
+    return;
+  }
+
+  if (
+    transferEntry.transfer_type === 2 &&
+    transferEntry.min_transfer_time === undefined
+  ) {
+    console.info(
+      `Missing minimum transfer time between ${transferEntry.from_stop_id} and ${transferEntry.to_stop_id}.`,
+    );
+  }
+
+  const transfer: Transfer = {
+    destination: toStop,
+    type: parseGtfsTransferType(transferEntry.transfer_type),
+    ...(transferEntry.min_transfer_time !== undefined && {
+      minTransferTime: Duration.fromSeconds(transferEntry.min_transfer_time),
+    }),
+  };
+
+  const fromStopTransfers = transfers.get(fromStop) || [];
+  fromStopTransfers.push(transfer);
+  transfers.set(fromStop, fromStopTransfers);
+};
+
+/**
  * Parses the transfers.txt file from a GTFS feed.
  *
  * @param stopsStream The readable stream containing the stops data.
@@ -53,10 +185,13 @@ export const parseTransfers = async (
   stopsMap: GtfsStopsMap,
 ): Promise<{
   transfers: TransfersMap;
-  tripContinuations: GtfsTripContinuation[];
+  tripContinuations: GtfsTripTransfer[];
+  guaranteedTripTransfers: GtfsTripTransfer[];
 }> => {
   const transfers: TransfersMap = new Map();
-  const tripContinuations: GtfsTripContinuation[] = [];
+  const tripContinuations: GtfsTripTransfer[] = [];
+  const guaranteedTripTransfers: GtfsTripTransfer[] = [];
+
   for await (const rawLine of parseCsv(transfersStream, [
     'transfer_type',
     'min_transfer_time',
@@ -69,6 +204,7 @@ export const parseTransfers = async (
     ) {
       continue;
     }
+
     if (!transferEntry.from_stop_id || !transferEntry.to_stop_id) {
       console.warn(`Missing transfer origin or destination stop.`);
       continue;
@@ -83,64 +219,56 @@ export const parseTransfers = async (
       continue;
     }
 
-    if (transferEntry.transfer_type === 4) {
-      if (
-        transferEntry.from_trip_id === undefined ||
-        transferEntry.from_trip_id === '' ||
-        transferEntry.to_trip_id === undefined ||
-        transferEntry.to_trip_id === ''
-      ) {
-        console.warn(
-          `Unsupported in-seat transfer, missing from_trip_id and/or to_trip_id.`,
+    switch (transferEntry.transfer_type) {
+      case 4: // In-seat transfer
+        processInSeatTransfer(
+          transferEntry,
+          fromStop.id,
+          toStop.id,
+          tripContinuations,
         );
-        continue;
-      }
-      const tripBoardingEntry: GtfsTripContinuation = {
-        fromStop: fromStop.id,
-        fromTrip: transferEntry.from_trip_id,
-        toStop: toStop.id,
-        toTrip: transferEntry.to_trip_id,
-      };
-      tripContinuations.push(tripBoardingEntry);
-      continue;
+        break;
+      case 1: // Guaranteed transfer
+        // If trip IDs are provided, treat as trip-to-trip guaranteed transfer
+        // Otherwise, treat as stop-to-stop guaranteed transfer
+        if (
+          transferEntry.from_trip_id &&
+          transferEntry.from_trip_id !== '' &&
+          transferEntry.to_trip_id &&
+          transferEntry.to_trip_id !== ''
+        ) {
+          processGuaranteedTripTransfer(
+            transferEntry,
+            fromStop.id,
+            toStop.id,
+            guaranteedTripTransfers,
+          );
+        } else {
+          processGuaranteedStopTransfer(
+            transferEntry,
+            fromStop.id,
+            toStop.id,
+            transfers,
+          );
+        }
+        break;
+      case 0: // Recommended transfer
+      case 2: // Requires minimal time
+      default:
+        processStopToStopTransfer(
+          transferEntry,
+          fromStop.id,
+          toStop.id,
+          transfers,
+        );
+        break;
     }
-    if (transferEntry.from_trip_id && transferEntry.to_trip_id) {
-      console.warn(
-        `Unsupported transfer of type ${transferEntry.transfer_type} between trips ${transferEntry.from_trip_id} and ${transferEntry.to_trip_id}.`,
-      );
-      continue;
-    }
-    if (transferEntry.from_route_id && transferEntry.to_route_id) {
-      console.warn(
-        `Unsupported transfer of type ${transferEntry.transfer_type} between routes ${transferEntry.from_route_id} and ${transferEntry.to_route_id}.`,
-      );
-      continue;
-    }
-
-    if (
-      transferEntry.transfer_type === 2 &&
-      transferEntry.min_transfer_time === undefined
-    ) {
-      console.info(
-        `Missing minimum transfer time between ${transferEntry.from_stop_id} and ${transferEntry.to_stop_id}.`,
-      );
-    }
-
-    const transfer: Transfer = {
-      destination: toStop.id,
-      type: parseGtfsTransferType(transferEntry.transfer_type),
-      ...(transferEntry.min_transfer_time !== undefined && {
-        minTransferTime: Duration.fromSeconds(transferEntry.min_transfer_time),
-      }),
-    };
-
-    const fromStopTransfers = transfers.get(fromStop.id) || [];
-    fromStopTransfers.push(transfer);
-    transfers.set(fromStop.id, fromStopTransfers);
   }
+
   return {
     transfers,
     tripContinuations,
+    guaranteedTripTransfers,
   };
 };
 
@@ -202,20 +330,20 @@ const disambiguateTransferStopsIndices = (
  * the most coherent transfer timing.
  *
  * @param tripsMapping Mapping from GTFS trip IDs to internal trip representations
- * @param tripContinuations Array of GTFS trip continuation data from transfers.txt
+ * @param gtfsTripTransfers Array of GTFS trip continuation data from transfers.txt
  * @param timetable The timetable containing route and timing information
  * @param activeStopIds Set of stop IDs that are active/enabled in the system
  * @returns A map from trip boarding IDs to arrays of continuation boarding options
  */
-export const buildTripContinuations = (
+export const buildTripTransfers = (
   tripsMapping: TripsMapping,
-  tripContinuations: GtfsTripContinuation[],
+  gtfsTripTransfers: GtfsTripTransfer[],
   timetable: Timetable,
   activeStopIds: Set<StopId>,
-): TripContinuations => {
-  const continuations: TripContinuations = new Map();
+): TripTransfers => {
+  const continuations: TripTransfers = new Map();
 
-  for (const gtfsContinuation of tripContinuations) {
+  for (const gtfsContinuation of gtfsTripTransfers) {
     if (
       !activeStopIds.has(gtfsContinuation.fromStop) ||
       !activeStopIds.has(gtfsContinuation.toStop)
@@ -246,25 +374,24 @@ export const buildTripContinuations = (
     );
 
     if (!bestStopIndices) {
-      // No valid continuation found
       continue;
     }
 
-    const tripBoardingId = encode(
+    const tripStopId = encode(
       bestStopIndices.fromStopIndex,
       fromTripMapping.routeId,
       fromTripMapping.tripRouteIndex,
     );
 
-    const continuationBoarding: TripBoarding = {
-      hopOnStopIndex: bestStopIndices.toStopIndex,
+    const continuationBoarding: TripStop = {
+      stopIndex: bestStopIndices.toStopIndex,
       routeId: toTripMapping.routeId,
       tripIndex: toTripMapping.tripRouteIndex,
     };
 
-    const existingContinuations = continuations.get(tripBoardingId) || [];
+    const existingContinuations = continuations.get(tripStopId) || [];
     existingContinuations.push(continuationBoarding);
-    continuations.set(tripBoardingId, existingContinuations);
+    continuations.set(tripStopId, existingContinuations);
   }
 
   return continuations;

--- a/src/routing/__tests__/plotter.test.ts
+++ b/src/routing/__tests__/plotter.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { Timetable } from '../../router.js';
 import { Stop, StopId } from '../../stops/stops.js';
 import { StopsIndex } from '../../stops/stopsIndex.js';
+import { Duration } from '../../timetable/duration.js';
 import { Route } from '../../timetable/route.js';
 import { Time } from '../../timetable/time.js';
 import { ServiceRoute, StopAdjacency } from '../../timetable/timetable.js';
@@ -182,8 +183,8 @@ describe('Plotter', () => {
           [
             1,
             {
-              from: 0,
-              to: 1,
+              stopIndex: 0,
+              hopOffStopIndex: 1,
               arrival: Time.fromHMS(8, 30, 0),
               routeId: 0,
               tripIndex: 0,
@@ -197,8 +198,8 @@ describe('Plotter', () => {
               from: 0,
               to: 1,
               arrival: Time.fromHMS(8, 45, 0),
-              type: 'WALKING',
-              minTransferTime: Time.fromHMS(0, 5, 0),
+              type: 'RECOMMENDED',
+              minTransferTime: Duration.fromMinutes(5),
             },
           ],
         ]),

--- a/src/routing/__tests__/result.test.ts
+++ b/src/routing/__tests__/result.test.ts
@@ -234,8 +234,8 @@ describe('Result', () => {
 
       const vehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 0, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
       };
@@ -274,8 +274,8 @@ describe('Result', () => {
 
       const vehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(10, 10, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 1,
         tripIndex: 0,
       };
@@ -287,8 +287,8 @@ describe('Result', () => {
             2,
             {
               arrival: Time.fromHMS(9, 10, 0),
-              from: 0,
-              to: 2,
+              stopIndex: 0,
+              hopOffStopIndex: 2,
               routeId: 0,
               tripIndex: 0,
             },
@@ -324,8 +324,8 @@ describe('Result', () => {
 
       const vehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 0, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
       };
@@ -364,16 +364,16 @@ describe('Result', () => {
 
       const firstVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 0, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
       };
 
       const secondVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 45, 0),
-        from: 0,
-        to: 1,
+        stopIndex: 0,
+        hopOffStopIndex: 1,
         routeId: 1,
         tripIndex: 0,
       };
@@ -418,8 +418,8 @@ describe('Result', () => {
 
       const vehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 0, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
       };
@@ -458,8 +458,8 @@ describe('Result', () => {
 
       const vehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 0, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
       };
@@ -500,16 +500,16 @@ describe('Result', () => {
 
       const firstVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(8, 30, 0),
-        from: 0,
-        to: 1,
+        stopIndex: 0,
+        hopOffStopIndex: 1,
         routeId: 0,
         tripIndex: 0,
       };
 
       const continuousVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 0, 0),
-        from: 1,
-        to: 2,
+        stopIndex: 1,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
         continuationOf: firstVehicleEdge,
@@ -551,16 +551,16 @@ describe('Result', () => {
 
       const firstVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 0, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
       };
 
       const continuousVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 45, 0),
-        from: 0,
-        to: 1,
+        stopIndex: 0,
+        hopOffStopIndex: 1,
         routeId: 1,
         tripIndex: 0,
         continuationOf: firstVehicleEdge,
@@ -601,8 +601,8 @@ describe('Result', () => {
 
       const firstVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(8, 30, 0),
-        from: 0,
-        to: 1,
+        stopIndex: 0,
+        hopOffStopIndex: 1,
         routeId: 0,
         tripIndex: 0,
       };
@@ -615,8 +615,8 @@ describe('Result', () => {
       };
       const secondVehicleEdge: VehicleEdge = {
         arrival: Time.fromHMS(9, 15, 0),
-        from: 0,
-        to: 1,
+        stopIndex: 0,
+        hopOffStopIndex: 1,
         routeId: 1,
         tripIndex: 0,
       };
@@ -772,16 +772,16 @@ describe('Result', () => {
 
       const vehicleEdge1: VehicleEdge = {
         arrival: Time.fromHMS(9, 30, 0),
-        from: 0,
-        to: 2,
+        stopIndex: 0,
+        hopOffStopIndex: 2,
         routeId: 0,
         tripIndex: 0,
       };
 
       const vehicleEdge2: VehicleEdge = {
         arrival: Time.fromHMS(9, 45, 0),
-        from: 0,
-        to: 1,
+        stopIndex: 0,
+        hopOffStopIndex: 1,
         routeId: 1,
         tripIndex: 0,
       };

--- a/src/routing/__tests__/router.test.ts
+++ b/src/routing/__tests__/router.test.ts
@@ -10,9 +10,9 @@ import {
   ServiceRoute,
   StopAdjacency,
   Timetable,
-  TripContinuations,
+  TripTransfers,
 } from '../../timetable/timetable.js';
-import { encode } from '../../timetable/tripBoardingId.js';
+import { encode } from '../../timetable/tripStopId.js';
 import { Query } from '../query.js';
 import { Result } from '../result.js';
 import { Router } from '../router.js';
@@ -23,13 +23,16 @@ describe('Router', () => {
     let timetable: Timetable;
 
     beforeEach(() => {
+      // Setup: A single route (Line 1) serving 3 stops in sequence
+      // Route 0: stop1 (depart 08:10) -> stop2 (08:15-08:25) -> stop3 (arrive 08:35)
       const stopsAdjacency: StopAdjacency[] = [
-        { routes: [0] },
-        { routes: [0] },
-        { routes: [0] },
+        { routes: [0] }, // stop 0 (stop1)
+        { routes: [0] }, // stop 1 (stop2)
+        { routes: [0] }, // stop 2 (stop3)
       ];
 
       const routesAdjacency = [
+        // Route 0: stops 0 -> 1 -> 2
         Route.of({
           id: 0,
           serviceRouteId: 0,
@@ -108,8 +111,11 @@ describe('Router', () => {
 
       const result: Result = router.route(query);
       const bestRoute = result.bestRoute();
+
+      // Should find a single-leg direct route on Line 1: stop1 -> stop3
       assert.strictEqual(bestRoute?.legs.length, 1);
     });
+
     it('should return an empty result when no route is possible', () => {
       const query = new Query.Builder()
         .from('stop1')
@@ -118,8 +124,9 @@ describe('Router', () => {
         .build();
 
       const result: Result = router.route(query);
-
       const bestRoute = result.bestRoute();
+
+      // No route exists to a non-existent stop
       assert.strictEqual(bestRoute, undefined);
     });
 
@@ -131,27 +138,35 @@ describe('Router', () => {
         .build();
 
       const result: Result = router.route(query);
-
       const timeToStop3 = result.arrivalAt('stop3');
+
+      // Route 0 arrives at stop3 at 08:35
       assert.strictEqual(
         timeToStop3?.arrival.toMinutes(),
         Time.fromString('08:35:00').toMinutes(),
       );
     });
   });
+
   describe('with a route change', () => {
     let router: Router;
     let timetable: Timetable;
 
     beforeEach(() => {
+      // Setup: Two routes that share stop2, enabling a same-stop transfer (route change)
+      // Route 0 (Line 1): stop1 (depart 08:15) -> stop2 (08:30-08:45) -> stop3 (09:00)
+      // Route 1 (Line 2): stop4 (depart 08:20) -> stop2 (09:00-09:15) -> stop5 (09:20)
+      // Both routes serve stop2, allowing transfer without walking
       const stopsAdjacency: StopAdjacency[] = [
-        { routes: [0] },
-        { routes: [0, 1] },
-        { routes: [0] },
-        { routes: [1] },
-        { routes: [1] },
+        { routes: [0] }, // stop 0 (stop1)
+        { routes: [0, 1] }, // stop 1 (stop2) - shared by both routes
+        { routes: [0] }, // stop 2 (stop3)
+        { routes: [1] }, // stop 3 (stop4)
+        { routes: [1] }, // stop 4 (stop5)
       ];
+
       const routesAdjacency = [
+        // Route 0: stops 0 -> 1 -> 2
         Route.of({
           id: 0,
           serviceRouteId: 0,
@@ -177,6 +192,7 @@ describe('Router', () => {
             },
           ],
         }),
+        // Route 1: stops 3 -> 1 -> 4
         Route.of({
           id: 1,
           serviceRouteId: 1,
@@ -280,6 +296,11 @@ describe('Router', () => {
 
       const result: Result = router.route(query);
       const bestRoute = result.bestRoute();
+
+      // Should find a route with 2 legs:
+      // 1. Line 1: stop1 -> stop2 (arrive 08:30)
+      // 2. Line 2: stop2 -> stop5 (depart 09:15, arrive 09:20)
+      // Transfer at stop2 with 30 minutes to spare (default minTransferTime is 2 min)
       assert.strictEqual(bestRoute?.legs.length, 2);
     });
 
@@ -291,38 +312,45 @@ describe('Router', () => {
         .build();
 
       const result: Result = router.route(query);
-
       const timeToStop5 = result.arrivalAt('stop5');
+
+      // Line 2 arrives at stop5 at 09:20
       assert.strictEqual(
         timeToStop5?.arrival.toMinutes(),
         Time.fromString('09:20:00').toMinutes(),
       );
     });
   });
-  describe('with a transfer', () => {
+
+  describe('with a walking transfer', () => {
     let router: Router;
     let timetable: Timetable;
 
     beforeEach(() => {
+      // Setup: Two routes that don't share any stops, connected by a walking transfer
+      // Route 0 (Line 1): stop1 (depart 08:15) -> stop2 (08:25-08:35) -> stop3 (08:45)
+      // Route 1 (Line 2): stop4 (depart 08:20) -> stop5 (08:40-08:50) -> stop6 (09:10)
+      // Walking transfer from stop2 to stop5 with 5 minute minTransferTime
       const stopsAdjacency: StopAdjacency[] = [
-        { routes: [0] },
+        { routes: [0] }, // stop 0 (stop1)
         {
           transfers: [
             {
               destination: 4,
               type: 'REQUIRES_MINIMAL_TIME',
-              minTransferTime: Duration.fromSeconds(300),
+              minTransferTime: Duration.fromSeconds(300), // 5 minutes walking
             },
           ],
           routes: [0],
-        },
-        { routes: [0] },
-        { routes: [1] },
-        { routes: [1] },
-        { routes: [1] },
+        }, // stop 1 (stop2) - has walking transfer to stop5
+        { routes: [0] }, // stop 2 (stop3)
+        { routes: [1] }, // stop 3 (stop4)
+        { routes: [1] }, // stop 4 (stop5)
+        { routes: [1] }, // stop 5 (stop6)
       ];
 
       const routesAdjacency = [
+        // Route 0: stops 0 -> 1 -> 2
         Route.of({
           id: 0,
           serviceRouteId: 0,
@@ -348,6 +376,7 @@ describe('Router', () => {
             },
           ],
         }),
+        // Route 1: stops 3 -> 4 -> 5
         Route.of({
           id: 1,
           serviceRouteId: 1,
@@ -449,7 +478,7 @@ describe('Router', () => {
       router = new Router(timetable, stopsIndex);
     });
 
-    it('should find a route with a transfer', () => {
+    it('should find a route with a walking transfer', () => {
       const query = new Query.Builder()
         .from('stop1')
         .to('stop6')
@@ -457,12 +486,16 @@ describe('Router', () => {
         .build();
 
       const result: Result = router.route(query);
-
       const bestRoute = result.bestRoute();
+
+      // Should find a route with 3 legs:
+      // 1. Line 1: stop1 -> stop2 (arrive 08:25)
+      // 2. Walking transfer: stop2 -> stop5 (5 min walk, arrive 08:30)
+      // 3. Line 2: stop5 -> stop6 (depart 08:50, arrive 09:10)
       assert.strictEqual(bestRoute?.legs.length, 3);
     });
 
-    it('should correctly calculate the time to a stop', () => {
+    it('should correctly calculate the arrival time at intermediate stop', () => {
       const query = new Query.Builder()
         .from('stop1')
         .to('stop6')
@@ -470,28 +503,36 @@ describe('Router', () => {
         .build();
 
       const result: Result = router.route(query);
-
       const timeToStop5 = result.arrivalAt('stop5');
+
+      // Arrive at stop2 at 08:25, walk 5 min to stop5, arrive at 08:30
       assert.strictEqual(
         timeToStop5?.arrival.toMinutes(),
         Time.fromString('08:30:00').toMinutes(),
       );
     });
   });
+
   describe('with a faster change', () => {
     let router: Router;
     let timetable: Timetable;
 
     beforeEach(() => {
+      // Setup: Three routes where Route 2 is direct but slower than Route 0 + Route 1 with a change
+      // Route 0 (Line 1): stop1 (08:15) -> stop2 (08:30-08:45) -> stop3 (09:00)
+      // Route 1 (Line 2): stop4 (08:25) -> stop2 (08:50-09:05) -> stop5 (09:10)
+      // Route 2 (Line 3): stop1 (08:15) -> stop5 (09:45) - direct but slower
+      // The router should prefer Route 0 + Route 1 (arrive 09:10) over Route 2 (arrive 09:45)
       const stopsAdjacency: StopAdjacency[] = [
-        { routes: [0, 2] },
-        { routes: [0, 1] },
-        { routes: [0] },
-        { routes: [1] },
-        { routes: [1, 2] },
+        { routes: [0, 2] }, // stop 0 (stop1) - served by Line 1 and Line 3
+        { routes: [0, 1] }, // stop 1 (stop2) - transfer point
+        { routes: [0] }, // stop 2 (stop3)
+        { routes: [1] }, // stop 3 (stop4)
+        { routes: [1, 2] }, // stop 4 (stop5) - destination
       ];
 
       const routesAdjacency = [
+        // Route 0: stops 0 -> 1 -> 2
         Route.of({
           id: 0,
           serviceRouteId: 0,
@@ -517,6 +558,7 @@ describe('Router', () => {
             },
           ],
         }),
+        // Route 1: stops 3 -> 1 -> 4
         Route.of({
           id: 1,
           serviceRouteId: 1,
@@ -542,6 +584,7 @@ describe('Router', () => {
             },
           ],
         }),
+        // Route 2: stops 0 -> 4 (direct but slow)
         Route.of({
           id: 2,
           serviceRouteId: 2,
@@ -634,7 +677,7 @@ describe('Router', () => {
       router = new Router(timetable, stopsIndex);
     });
 
-    it('should find a faster route with a change', () => {
+    it('should prefer a faster route with a change over a slower direct route', () => {
       const query = new Query.Builder()
         .from('stop1')
         .to('stop5')
@@ -642,8 +685,10 @@ describe('Router', () => {
         .build();
 
       const result: Result = router.route(query);
-
       const bestRoute = result.bestRoute();
+
+      // Should prefer the 2-leg route (Line 1 + Line 2, arrive 09:10)
+      // over the 1-leg direct route (Line 3, arrive 09:45)
       assert.strictEqual(bestRoute?.legs.length, 2);
     });
   });
@@ -653,18 +698,21 @@ describe('Router', () => {
     let timetable: Timetable;
 
     beforeEach(() => {
-      // Setup: Route 0 continues as Route 1 at stop 1
-      const tripContinuations: TripContinuations = new Map([
-        [encode(1, 0, 0), [{ hopOnStopIndex: 1, routeId: 1, tripIndex: 0 }]],
+      // Setup: Route 0 continues as Route 1 at stop2 (same vehicle, different route number)
+      // This is an "in-seat transfer" where passengers can stay on the vehicle
+      // Route 0 (Line 1): stop1 (depart 08:10) -> stop2 (08:15-08:25)
+      // Route 1 (Line 2): stop2 (08:15-08:25) -> stop3 (08:35) -> stop4 (08:55)
+      // Trip continuation: Route 0 trip 0 at stop2 continues as Route 1 trip 0
+      // encode(1, 0, 0) = stop index 1 on route 0, trip 0 (where the continuation starts)
+      const tripContinuations: TripTransfers = new Map([
+        [encode(1, 0, 0), [{ stopIndex: 0, routeId: 1, tripIndex: 0 }]],
       ]);
 
       const stopsAdjacency: StopAdjacency[] = [
-        { routes: [0] },
-        {
-          routes: [0, 1],
-        },
-        { routes: [1] },
-        { routes: [1] },
+        { routes: [0] }, // stop 0 (stop1)
+        { routes: [0, 1] }, // stop 1 (stop2) - continuation point
+        { routes: [1] }, // stop 2 (stop3)
+        { routes: [1] }, // stop 3 (stop4)
       ];
 
       const routesAdjacency = [
@@ -803,11 +851,791 @@ describe('Router', () => {
         .build();
 
       const result: Result = router.route(query);
-
       const timeToStop4 = result.arrivalAt('stop4');
+
+      // Route 1 (continuation of Route 0) arrives at stop4 at 08:55
       assert.strictEqual(
         timeToStop4?.arrival.toMinutes(),
         Time.fromString('08:55:00').toMinutes(),
+      );
+    });
+  });
+
+  describe('with guaranteed trip transfers', () => {
+    let router: Router;
+    let timetable: Timetable;
+
+    beforeEach(() => {
+      // Setup: Route 0 trip 0 has a guaranteed transfer to Route 1 trip 0 at stop2
+      // The transfer time is only 1 minute (60 seconds), less than the 5-minute minTransferTime
+      // But since it's guaranteed, it should still be considered
+      // Route 0: stop1 (depart 08:10) -> stop2 (arrive 08:20)
+      // Route 1: stop2 (depart 08:21) -> stop3 (arrive 08:40)
+      // encode(1, 0, 0) = stop index 1 on route 0, trip 0 (where we alight)
+      // destination { stopIndex: 0, routeId: 1, tripIndex: 0 } = stop index 0 on route 1, trip 0 (where we board)
+      const guaranteedTripTransfers: TripTransfers = new Map([
+        [encode(1, 0, 0), [{ stopIndex: 0, routeId: 1, tripIndex: 0 }]],
+      ]);
+
+      const stopsAdjacency: StopAdjacency[] = [
+        { routes: [0] }, // stop 0 (stop1)
+        { routes: [0, 1] }, // stop 1 (stop2) - both routes serve this stop
+        { routes: [1] }, // stop 2 (stop3)
+      ];
+
+      const routesAdjacency = [
+        // Route 0: stops 0 -> 1
+        Route.of({
+          id: 0,
+          serviceRouteId: 0,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 0,
+                  arrivalTime: Time.fromString('08:00:00'),
+                  departureTime: Time.fromString('08:10:00'),
+                },
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:20:00'),
+                  departureTime: Time.fromString('08:30:00'),
+                },
+              ],
+            },
+          ],
+        }),
+        // Route 1: stops 1 -> 2
+        // Departure at 08:21, only 1 minute after arrival from route 0
+        // Without the guaranteed transfer, this would be missed with a 5-minute minTransferTime
+        Route.of({
+          id: 1,
+          serviceRouteId: 1,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:15:00'),
+                  departureTime: Time.fromString('08:21:00'),
+                },
+                {
+                  id: 2,
+                  arrivalTime: Time.fromString('08:40:00'),
+                  departureTime: Time.fromString('08:50:00'),
+                },
+              ],
+            },
+          ],
+        }),
+      ];
+
+      const routes: ServiceRoute[] = [
+        {
+          type: 'BUS',
+          name: 'Line 1',
+          routes: [0],
+        },
+        {
+          type: 'BUS',
+          name: 'Line 2',
+          routes: [1],
+        },
+      ];
+
+      timetable = new Timetable(
+        stopsAdjacency,
+        routesAdjacency,
+        routes,
+        undefined, // no trip continuations
+        guaranteedTripTransfers,
+      );
+
+      const stops: Stop[] = [
+        {
+          id: 0,
+          sourceStopId: 'stop1',
+          name: 'Stop 1',
+          lat: 1.0,
+          lon: 1.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 1,
+          sourceStopId: 'stop2',
+          name: 'Stop 2',
+          lat: 2.0,
+          lon: 2.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 2,
+          sourceStopId: 'stop3',
+          name: 'Stop 3',
+          lat: 3.0,
+          lon: 3.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ];
+
+      const stopsIndex = new StopsIndex(stops);
+      router = new Router(timetable, stopsIndex);
+    });
+
+    it('should consider guaranteed transfer even with less time than minTransferTime', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop3')
+        .departureTime(Time.fromString('08:00:00'))
+        .minTransferTime(Duration.fromSeconds(300)) // 5 minutes, but transfer only has 1 minute
+        .build();
+
+      const result: Result = router.route(query);
+      const bestRoute = result.bestRoute();
+
+      // Should find a route with 3 legs:
+      // 1. Vehicle leg (route 0)
+      // 2. Guaranteed transfer leg (shown as type: 'GUARANTEED')
+      // 3. Vehicle leg (route 1)
+      assert.ok(bestRoute);
+      assert.strictEqual(bestRoute.legs.length, 3);
+
+      // The middle leg should be the guaranteed transfer
+      const transferLeg = bestRoute.legs[1];
+      assert.ok(transferLeg && 'type' in transferLeg);
+      assert.strictEqual(transferLeg.type, 'GUARANTEED');
+
+      // Should arrive at 08:40 because the guaranteed transfer allows catching
+      // the 08:21 departure despite only having 1 minute of transfer time
+      assert.strictEqual(
+        result.arrivalAt('stop3')?.arrival.toMinutes(),
+        Time.fromString('08:40:00').toMinutes(),
+      );
+    });
+  });
+
+  describe('with non-guaranteed transfers and minTransferTime', () => {
+    let router: Router;
+    let timetable: Timetable;
+
+    beforeEach(() => {
+      // Setup: Same-stop transfer (route change) without guaranteed transfer
+      // Both routes serve stop2, so this is a route change at the same stop
+      // The query's minTransferTime should be respected
+      // Route 0: stop1 (depart 08:10) -> stop2 (arrive 08:20)
+      // Route 1 trip 0: stop2 (depart 08:21) -> stop3 (arrive 08:35) - NOT catchable with 5 min minTransferTime
+      // Route 1 trip 1: stop2 (depart 08:26) -> stop3 (arrive 08:45) - catchable with 5 min minTransferTime
+      const stopsAdjacency: StopAdjacency[] = [
+        { routes: [0] }, // stop 0 (stop1)
+        { routes: [0, 1] }, // stop 1 (stop2) - both routes serve this stop
+        { routes: [1] }, // stop 2 (stop3)
+      ];
+
+      const routesAdjacency = [
+        // Route 0: stops 0 -> 1
+        Route.of({
+          id: 0,
+          serviceRouteId: 0,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 0,
+                  arrivalTime: Time.fromString('08:00:00'),
+                  departureTime: Time.fromString('08:10:00'),
+                },
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:20:00'),
+                  departureTime: Time.fromString('08:30:00'),
+                },
+              ],
+            },
+          ],
+        }),
+        // Route 1: stops 1 -> 2
+        // Trip 0: Departure at 08:21, only 1 minute after arrival - should NOT be catchable with 5 min minTransferTime
+        // Trip 1: Departure at 08:26, 6 minutes after arrival - should be catchable with 5 min minTransferTime
+        Route.of({
+          id: 1,
+          serviceRouteId: 1,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:15:00'),
+                  departureTime: Time.fromString('08:21:00'),
+                },
+                {
+                  id: 2,
+                  arrivalTime: Time.fromString('08:35:00'),
+                  departureTime: Time.fromString('08:45:00'),
+                },
+              ],
+            },
+            {
+              stops: [
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:20:00'),
+                  departureTime: Time.fromString('08:26:00'),
+                },
+                {
+                  id: 2,
+                  arrivalTime: Time.fromString('08:45:00'),
+                  departureTime: Time.fromString('08:55:00'),
+                },
+              ],
+            },
+          ],
+        }),
+      ];
+
+      const routes: ServiceRoute[] = [
+        {
+          type: 'BUS',
+          name: 'Line 1',
+          routes: [0],
+        },
+        {
+          type: 'BUS',
+          name: 'Line 2',
+          routes: [1],
+        },
+      ];
+
+      timetable = new Timetable(stopsAdjacency, routesAdjacency, routes);
+
+      const stops: Stop[] = [
+        {
+          id: 0,
+          sourceStopId: 'stop1',
+          name: 'Stop 1',
+          lat: 1.0,
+          lon: 1.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 1,
+          sourceStopId: 'stop2',
+          name: 'Stop 2',
+          lat: 2.0,
+          lon: 2.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 2,
+          sourceStopId: 'stop3',
+          name: 'Stop 3',
+          lat: 3.0,
+          lon: 3.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ];
+
+      const stopsIndex = new StopsIndex(stops);
+      router = new Router(timetable, stopsIndex);
+    });
+
+    it('should not consider transfer with less time than minTransferTime', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop3')
+        .departureTime(Time.fromString('08:00:00'))
+        .minTransferTime(Duration.fromSeconds(300)) // 5 minutes required for transfer
+        .build();
+
+      const result: Result = router.route(query);
+      const bestRoute = result.bestRoute();
+
+      // Should find a route with 2 legs (same-stop transfer, no walking):
+      // 1. Vehicle leg on route 0 (stop1 -> stop2)
+      // 2. Vehicle leg on route 1 (stop2 -> stop3)
+      assert.strictEqual(bestRoute?.legs.length, 2);
+
+      // Arrival at stop2 is 08:20, with 5 min minTransferTime we need departure >= 08:25
+      // Trip 0 of route 1 departs at 08:21 - NOT catchable (only 1 minute transfer time)
+      // Trip 1 of route 1 departs at 08:26 - catchable (6 minutes transfer time)
+      // So we should arrive at stop3 at 08:45 (trip 1 arrival), not 08:35 (trip 0 arrival)
+      assert.strictEqual(
+        result.arrivalAt('stop3')?.arrival.toMinutes(),
+        Time.fromString('08:45:00').toMinutes(),
+      );
+    });
+  });
+
+  describe('with maxTransfers constraint', () => {
+    let router: Router;
+    let timetable: Timetable;
+
+    beforeEach(() => {
+      // Setup: Three routes where reaching stop4 requires 2 transfers
+      // Route 0: stop1 -> stop2
+      // Route 1: stop2 -> stop3
+      // Route 2: stop3 -> stop4
+      // With maxTransfers=1, stop4 should not be reachable
+      // With maxTransfers=2, stop4 should be reachable
+      const stopsAdjacency: StopAdjacency[] = [
+        { routes: [0] }, // stop 0 (stop1)
+        { routes: [0, 1] }, // stop 1 (stop2)
+        { routes: [1, 2] }, // stop 2 (stop3)
+        { routes: [2] }, // stop 3 (stop4)
+      ];
+
+      const routesAdjacency = [
+        // Route 0: stops 0 -> 1
+        Route.of({
+          id: 0,
+          serviceRouteId: 0,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 0,
+                  arrivalTime: Time.fromString('08:00:00'),
+                  departureTime: Time.fromString('08:10:00'),
+                },
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:20:00'),
+                  departureTime: Time.fromString('08:30:00'),
+                },
+              ],
+            },
+          ],
+        }),
+        // Route 1: stops 1 -> 2
+        Route.of({
+          id: 1,
+          serviceRouteId: 1,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:25:00'),
+                  departureTime: Time.fromString('08:35:00'),
+                },
+                {
+                  id: 2,
+                  arrivalTime: Time.fromString('08:45:00'),
+                  departureTime: Time.fromString('08:55:00'),
+                },
+              ],
+            },
+          ],
+        }),
+        // Route 2: stops 2 -> 3
+        Route.of({
+          id: 2,
+          serviceRouteId: 2,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 2,
+                  arrivalTime: Time.fromString('08:50:00'),
+                  departureTime: Time.fromString('09:00:00'),
+                },
+                {
+                  id: 3,
+                  arrivalTime: Time.fromString('09:10:00'),
+                  departureTime: Time.fromString('09:20:00'),
+                },
+              ],
+            },
+          ],
+        }),
+      ];
+
+      const routes: ServiceRoute[] = [
+        { type: 'BUS', name: 'Line 1', routes: [0] },
+        { type: 'BUS', name: 'Line 2', routes: [1] },
+        { type: 'BUS', name: 'Line 3', routes: [2] },
+      ];
+
+      timetable = new Timetable(stopsAdjacency, routesAdjacency, routes);
+
+      const stops: Stop[] = [
+        {
+          id: 0,
+          sourceStopId: 'stop1',
+          name: 'Stop 1',
+          lat: 1.0,
+          lon: 1.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 1,
+          sourceStopId: 'stop2',
+          name: 'Stop 2',
+          lat: 2.0,
+          lon: 2.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 2,
+          sourceStopId: 'stop3',
+          name: 'Stop 3',
+          lat: 3.0,
+          lon: 3.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 3,
+          sourceStopId: 'stop4',
+          name: 'Stop 4',
+          lat: 4.0,
+          lon: 4.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ];
+
+      const stopsIndex = new StopsIndex(stops);
+      router = new Router(timetable, stopsIndex);
+    });
+
+    it('should not find route when maxTransfers is too low', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop4')
+        .departureTime(Time.fromString('08:00:00'))
+        .maxTransfers(1) // Only allows 1 transfer, but we need 2
+        .build();
+
+      const result: Result = router.route(query);
+      const bestRoute = result.bestRoute();
+
+      // Should not find a route because reaching stop4 requires 2 transfers
+      assert.strictEqual(bestRoute, undefined);
+    });
+
+    it('should find route when maxTransfers is sufficient', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop4')
+        .departureTime(Time.fromString('08:00:00'))
+        .maxTransfers(2) // Allows 2 transfers, which is exactly what we need
+        .build();
+
+      const result: Result = router.route(query);
+      const bestRoute = result.bestRoute();
+
+      // Should find a route with 3 legs (2 transfers)
+      assert.strictEqual(bestRoute?.legs.length, 3);
+    });
+
+    it('should find intermediate stops even with low maxTransfers', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop4')
+        .departureTime(Time.fromString('08:00:00'))
+        .maxTransfers(1)
+        .build();
+
+      const result: Result = router.route(query);
+
+      // stop3 should still be reachable with 1 transfer (stop1 -> stop2 -> stop3)
+      const arrivalAtStop3 = result.arrivalAt('stop3');
+      assert.ok(arrivalAtStop3);
+      assert.strictEqual(
+        arrivalAtStop3.arrival.toMinutes(),
+        Time.fromString('08:45:00').toMinutes(),
+      );
+    });
+  });
+
+  describe('with transport mode filtering', () => {
+    let router: Router;
+    let timetable: Timetable;
+
+    beforeEach(() => {
+      // Setup: Two routes to the same destination with different transport modes
+      // Route 0 (BUS): stop1 -> stop2, arrives 08:30
+      // Route 1 (RAIL): stop1 -> stop2, arrives 08:20 (faster)
+      // When filtering to BUS only, should use the slower bus route
+      const stopsAdjacency: StopAdjacency[] = [
+        { routes: [0, 1] }, // stop 0 (stop1) - served by both routes
+        { routes: [0, 1] }, // stop 1 (stop2) - served by both routes
+      ];
+
+      const routesAdjacency = [
+        // Route 0 (BUS): stops 0 -> 1, slower
+        Route.of({
+          id: 0,
+          serviceRouteId: 0,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 0,
+                  arrivalTime: Time.fromString('08:00:00'),
+                  departureTime: Time.fromString('08:10:00'),
+                },
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:30:00'),
+                  departureTime: Time.fromString('08:40:00'),
+                },
+              ],
+            },
+          ],
+        }),
+        // Route 1 (RAIL): stops 0 -> 1, faster
+        Route.of({
+          id: 1,
+          serviceRouteId: 1,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 0,
+                  arrivalTime: Time.fromString('08:00:00'),
+                  departureTime: Time.fromString('08:10:00'),
+                },
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:20:00'),
+                  departureTime: Time.fromString('08:30:00'),
+                },
+              ],
+            },
+          ],
+        }),
+      ];
+
+      const routes: ServiceRoute[] = [
+        { type: 'BUS', name: 'Bus Line', routes: [0] },
+        { type: 'RAIL', name: 'Rail Line', routes: [1] },
+      ];
+
+      timetable = new Timetable(stopsAdjacency, routesAdjacency, routes);
+
+      const stops: Stop[] = [
+        {
+          id: 0,
+          sourceStopId: 'stop1',
+          name: 'Stop 1',
+          lat: 1.0,
+          lon: 1.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 1,
+          sourceStopId: 'stop2',
+          name: 'Stop 2',
+          lat: 2.0,
+          lon: 2.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ];
+
+      const stopsIndex = new StopsIndex(stops);
+      router = new Router(timetable, stopsIndex);
+    });
+
+    it('should use fastest route when all modes allowed', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop2')
+        .departureTime(Time.fromString('08:00:00'))
+        .build();
+
+      const result: Result = router.route(query);
+
+      // Should use the faster RAIL route, arriving at 08:20
+      assert.strictEqual(
+        result.arrivalAt('stop2')?.arrival.toMinutes(),
+        Time.fromString('08:20:00').toMinutes(),
+      );
+    });
+
+    it('should only use allowed transport modes', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop2')
+        .departureTime(Time.fromString('08:00:00'))
+        .transportModes(new Set(['BUS'] as const))
+        .build();
+
+      const result: Result = router.route(query);
+
+      // Should use the slower BUS route since RAIL is excluded, arriving at 08:30
+      assert.strictEqual(
+        result.arrivalAt('stop2')?.arrival.toMinutes(),
+        Time.fromString('08:30:00').toMinutes(),
+      );
+    });
+
+    it('should return no route when no matching transport mode', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop2')
+        .departureTime(Time.fromString('08:00:00'))
+        .transportModes(new Set(['FERRY'] as const)) // Neither route is a ferry
+        .build();
+
+      const result: Result = router.route(query);
+      const bestRoute = result.bestRoute();
+
+      // No route should be found since neither BUS nor RAIL is allowed
+      assert.strictEqual(bestRoute, undefined);
+    });
+  });
+
+  describe('with timing edge cases', () => {
+    let router: Router;
+    let timetable: Timetable;
+
+    beforeEach(() => {
+      // Setup: A single route with multiple trips at different times
+      // Trip 0: departs 08:10, arrives 08:30
+      // Trip 1: departs 09:10, arrives 09:30
+      const stopsAdjacency: StopAdjacency[] = [
+        { routes: [0] },
+        { routes: [0] },
+      ];
+
+      const routesAdjacency = [
+        Route.of({
+          id: 0,
+          serviceRouteId: 0,
+          trips: [
+            {
+              stops: [
+                {
+                  id: 0,
+                  arrivalTime: Time.fromString('08:00:00'),
+                  departureTime: Time.fromString('08:10:00'),
+                },
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('08:30:00'),
+                  departureTime: Time.fromString('08:40:00'),
+                },
+              ],
+            },
+            {
+              stops: [
+                {
+                  id: 0,
+                  arrivalTime: Time.fromString('09:00:00'),
+                  departureTime: Time.fromString('09:10:00'),
+                },
+                {
+                  id: 1,
+                  arrivalTime: Time.fromString('09:30:00'),
+                  departureTime: Time.fromString('09:40:00'),
+                },
+              ],
+            },
+          ],
+        }),
+      ];
+
+      const routes: ServiceRoute[] = [
+        { type: 'BUS', name: 'Line 1', routes: [0] },
+      ];
+
+      timetable = new Timetable(stopsAdjacency, routesAdjacency, routes);
+
+      const stops: Stop[] = [
+        {
+          id: 0,
+          sourceStopId: 'stop1',
+          name: 'Stop 1',
+          lat: 1.0,
+          lon: 1.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+        {
+          id: 1,
+          sourceStopId: 'stop2',
+          name: 'Stop 2',
+          lat: 2.0,
+          lon: 2.0,
+          children: [],
+          locationType: 'SIMPLE_STOP_OR_PLATFORM',
+        },
+      ];
+
+      const stopsIndex = new StopsIndex(stops);
+      router = new Router(timetable, stopsIndex);
+    });
+
+    it('should find first available trip after departure time', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop2')
+        .departureTime(Time.fromString('08:00:00'))
+        .build();
+
+      const result: Result = router.route(query);
+
+      // Should catch the first trip (08:10), arriving at 08:30
+      assert.strictEqual(
+        result.arrivalAt('stop2')?.arrival.toMinutes(),
+        Time.fromString('08:30:00').toMinutes(),
+      );
+    });
+
+    it('should skip trips that have already departed', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop2')
+        .departureTime(Time.fromString('08:15:00')) // After first trip departs
+        .build();
+
+      const result: Result = router.route(query);
+
+      // Should catch the second trip (09:10), arriving at 09:30
+      assert.strictEqual(
+        result.arrivalAt('stop2')?.arrival.toMinutes(),
+        Time.fromString('09:30:00').toMinutes(),
+      );
+    });
+
+    it('should return no route when departing after all trips', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop2')
+        .departureTime(Time.fromString('10:00:00')) // After all trips have departed
+        .build();
+
+      const result: Result = router.route(query);
+      const bestRoute = result.bestRoute();
+
+      // No route should be found since all trips have departed
+      assert.strictEqual(bestRoute, undefined);
+    });
+
+    it('should catch trip when departure time exactly matches', () => {
+      const query = new Query.Builder()
+        .from('stop1')
+        .to('stop2')
+        .departureTime(Time.fromString('08:10:00')) // Exactly when first trip departs
+        .build();
+
+      const result: Result = router.route(query);
+
+      // Should still catch the first trip
+      assert.strictEqual(
+        result.arrivalAt('stop2')?.arrival.toMinutes(),
+        Time.fromString('08:30:00').toMinutes(),
       );
     });
   });

--- a/src/routing/plotter.ts
+++ b/src/routing/plotter.ts
@@ -2,30 +2,204 @@ import { StopId } from '../stops/stops.js';
 import { Result } from './result.js';
 import { RoutingEdge, TransferEdge, VehicleEdge } from './router.js';
 
+/**
+ * Configuration for DOT graph styling.
+ */
+const DOT_CONFIG = {
+  colors: {
+    rounds: [
+      '#60a5fa', // Round 1 - Blue
+      '#ff9800', // Round 2 - Orange
+      '#14b8a6', // Round 3 - Teal
+      '#fb7185', // Round 4 - Pink
+      '#ffdf00', // Round 5 - Yellow
+      '#b600ff', // Round 6 - Purple
+      '#ee82ee', // Round 7+ - Violet
+    ],
+    defaultRound: '#888888',
+    originStation: '#60a5fa',
+    destinationStation: '#ee82ee',
+    defaultStation: 'white',
+    continuationFill: '#ffffcc',
+  },
+  penWidth: {
+    default: 1,
+    continuation: 2,
+    continuationEdge: 3,
+  },
+} as const;
+
+/**
+ * Type guard to check if an edge is a VehicleEdge.
+ */
+function isVehicleEdge(edge: RoutingEdge): edge is VehicleEdge {
+  return 'routeId' in edge && 'stopIndex' in edge && 'hopOffStopIndex' in edge;
+}
+
+/**
+ * Type guard to check if an edge is a TransferEdge.
+ */
+function isTransferEdge(edge: RoutingEdge): edge is TransferEdge {
+  return 'from' in edge && 'to' in edge && 'type' in edge;
+}
+
+/**
+ * Helper class for building DOT graph syntax.
+ */
+class DotBuilder {
+  private lines: string[] = [];
+
+  /**
+   * Adds the DOT graph header with default styling.
+   */
+  addHeader(): this {
+    this.lines.push(
+      'digraph RoutingGraph {',
+      '  graph [overlap=false, splines=true, rankdir=TB, bgcolor=white, nodesep=0.8, ranksep=1.2, concentrate=true];',
+      '  node [fontname="Arial" margin=0.1];',
+      '  edge [fontname="Arial" fontsize=10];',
+    );
+    return this;
+  }
+
+  /**
+   * Adds a comment section to the graph.
+   */
+  addComment(comment: string): this {
+    this.lines.push('', `  // ${comment}`);
+    return this;
+  }
+
+  /**
+   * Adds a node with the given attributes.
+   */
+  addNode(id: string, attrs: Record<string, string>): this {
+    const attrStr = Object.entries(attrs)
+      .map(([k, v]) => `${k}="${v}"`)
+      .join(' ');
+    this.lines.push(`  "${id}" [${attrStr}];`);
+    return this;
+  }
+
+  /**
+   * Adds an edge between two nodes with optional attributes.
+   */
+  addEdge(from: string, to: string, attrs: Record<string, string> = {}): this {
+    const attrStr = Object.entries(attrs)
+      .map(([k, v]) => `${k}="${v}"`)
+      .join(' ');
+    const attrPart = attrStr ? ` [${attrStr}]` : '';
+    this.lines.push(`  "${from}" -> "${to}"${attrPart};`);
+    return this;
+  }
+
+  /**
+   * Adds raw lines to the graph.
+   */
+  addRaw(lines: string[]): this {
+    this.lines.push(...lines);
+    return this;
+  }
+
+  /**
+   * Builds the final DOT graph string.
+   */
+  build(): string {
+    this.lines.push('}');
+    return this.lines.join('\n');
+  }
+}
+
+/**
+ * Generates DOT graph visualizations of routing results.
+ *
+ * The generated graph shows:
+ * - Stations as rectangular nodes (origin=blue, destination=violet)
+ * - Vehicle edges as ovals with route info
+ * - Transfer edges as dashed ovals
+ * - Continuation edges (same-station transfers) as bold yellow ovals
+ *
+ * @example
+ * ```typescript
+ * const plotter = new Plotter(routingResult);
+ * const dotGraph = plotter.plotDotGraph();
+ * // Use with Graphviz: dot -Tpng -o graph.png
+ * ```
+ */
 export class Plotter {
   private result: Result;
-  private readonly ROUND_COLORS = [
-    '#60a5fa', // Round 1
-    '#ff9800', // Round 2
-    '#14b8a6', // Round 3
-    '#fb7185', // Round 4
-    '#ffdf00', // Round 5
-    '#b600ff', // Round 6
-    '#ee82ee', // Round 7+
-  ];
 
   constructor(result: Result) {
     this.result = result;
   }
 
   /**
-   * Gets the color for a round based on the specified palette.
+   * Generates a unique node ID for a station.
+   */
+  private stationNodeId(stopId: StopId): string {
+    return `s_${stopId}`;
+  }
+
+  /**
+   * Generates a unique node ID for a vehicle edge oval.
+   */
+  private vehicleEdgeNodeId(
+    fromStopId: StopId,
+    toStopId: StopId,
+    routeId: number,
+    round: number,
+  ): string {
+    return `e_${fromStopId}_${toStopId}_${routeId}_${round}`;
+  }
+
+  /**
+   * Generates a unique node ID for a transfer edge oval.
+   */
+  private transferEdgeNodeId(
+    fromStopId: StopId,
+    toStopId: StopId,
+    round: number,
+  ): string {
+    return `e_${fromStopId}_${toStopId}_${round}`;
+  }
+
+  /**
+   * Generates a unique node ID for a continuation edge oval.
+   */
+  private continuationNodeId(
+    fromStopId: StopId,
+    toStopId: StopId,
+    round: number,
+  ): string {
+    return `continuation_${fromStopId}_${toStopId}_${round}`;
+  }
+
+  /**
+   * Gets the color for a round based on the configured palette.
    */
   private getRoundColor(round: number): string {
-    if (round === 0) return '#888888';
+    if (round === 0) {
+      return DOT_CONFIG.colors.defaultRound;
+    }
 
-    const colorIndex = Math.min(round - 1, this.ROUND_COLORS.length - 1);
-    return this.ROUND_COLORS[colorIndex] ?? '#ee82ee';
+    const colorIndex = Math.min(round - 1, DOT_CONFIG.colors.rounds.length - 1);
+    return DOT_CONFIG.colors.rounds[colorIndex] ?? '#ee82ee';
+  }
+
+  /**
+   * Gets the appropriate fill color for a station based on its type.
+   */
+  private getStationFillColor(
+    isOrigin: boolean,
+    isDestination: boolean,
+  ): string {
+    if (isOrigin) {
+      return DOT_CONFIG.colors.originStation;
+    }
+    if (isDestination) {
+      return DOT_CONFIG.colors.destinationStation;
+    }
+    return DOT_CONFIG.colors.defaultStation;
   }
 
   /**
@@ -38,6 +212,25 @@ export class Plotter {
       .replace(/\n/g, '\\n')
       .replace(/\r/g, '\\r')
       .replace(/\t/g, '\\t');
+  }
+
+  /**
+   * Formats a stop name for display, including platform information.
+   */
+  private formatStopName(stopId: StopId): string {
+    const stop = this.result.stopsIndex.findStopById(stopId);
+    if (!stop) {
+      return `Unknown Stop (${stopId})`;
+    }
+
+    const escapedName = this.escapeDotString(stop.name);
+    const escapedPlatform = stop.platform
+      ? this.escapeDotString(stop.platform)
+      : '';
+
+    return escapedPlatform
+      ? `${escapedName}\\nPl. ${escapedPlatform}`
+      : escapedName;
   }
 
   /**
@@ -54,43 +247,33 @@ export class Plotter {
   }
 
   /**
-   * Formats a stop name for display, including platform information.
+   * Resolves the actual StopId from a VehicleEdge's stopIndex.
    */
-  private formatStopName(stopId: StopId): string {
-    const stop = this.result.stopsIndex.findStopById(stopId);
-    if (!stop) return `Unknown Stop (${stopId})`;
-
-    const escapedName = this.escapeDotString(stop.name);
-    const escapedPlatform = stop.platform
-      ? this.escapeDotString(stop.platform)
-      : '';
-    return escapedPlatform
-      ? `${escapedName}\\nPl. ${escapedPlatform}`
-      : escapedName;
+  private getVehicleEdgeFromStopId(edge: VehicleEdge): StopId | undefined {
+    const route = this.result.timetable.getRoute(edge.routeId);
+    return route?.stopId(edge.stopIndex);
   }
 
   /**
-   * Gets the appropriate fill color for a station based on its type.
+   * Resolves the actual StopId from a VehicleEdge's hopOffStopIndex.
    */
-  private getStationFillColor(
-    isOrigin: boolean,
-    isDestination: boolean,
-  ): string {
-    if (isOrigin) return '#60a5fa';
-    if (isDestination) return '#ee82ee';
-    return 'white';
+  private getVehicleEdgeToStopId(edge: VehicleEdge): StopId | undefined {
+    const route = this.result.timetable.getRoute(edge.routeId);
+    return route?.stopId(edge.hopOffStopIndex);
   }
 
   /**
    * Creates a DOT node for a station.
    */
-  private createStationNode(stopId: StopId): string {
+  private createStationNode(stopId: StopId): string | null {
     const stop = this.result.stopsIndex.findStopById(stopId);
-    if (!stop) return '';
+    if (!stop) {
+      return null;
+    }
 
     const displayName = this.formatStopName(stopId);
     const stopIdStr = this.escapeDotString(String(stopId));
-    const nodeId = `s_${stopId}`;
+    const nodeId = this.stationNodeId(stopId);
     const stationInfo = this.getStationInfo(stopId);
     const fillColor = this.getStationFillColor(
       stationInfo.isOrigin,
@@ -104,22 +287,30 @@ export class Plotter {
    * Creates a vehicle edge with route information oval in the middle.
    */
   private createVehicleEdge(edge: VehicleEdge, round: number): string[] {
-    const fromNodeId = `s_${edge.from}`;
-    const toNodeId = `s_${edge.to}`;
-    const roundColor = this.getRoundColor(round);
-    const routeOvalId = `e_${edge.from}_${edge.to}_${edge.routeId}_${round}`;
-
     const route = this.result.timetable.getRoute(edge.routeId);
-    const serviceRouteInfo = route
-      ? this.result.timetable.getServiceRouteInfo(route)
-      : null;
+    if (!route) {
+      return [];
+    }
 
-    const routeName = serviceRouteInfo?.name ?? `Route ${String(edge.routeId)}`;
-    const routeType = serviceRouteInfo?.type || 'UNKNOWN';
+    const fromStopId = route.stopId(edge.stopIndex);
+    const toStopId = route.stopId(edge.hopOffStopIndex);
+    const fromNodeId = this.stationNodeId(fromStopId);
+    const toNodeId = this.stationNodeId(toStopId);
+    const roundColor = this.getRoundColor(round);
+    const routeOvalId = this.vehicleEdgeNodeId(
+      fromStopId,
+      toStopId,
+      edge.routeId,
+      round,
+    );
+
+    const serviceRouteInfo = this.result.timetable.getServiceRouteInfo(route);
+    const routeName = serviceRouteInfo.name;
+    const routeType = serviceRouteInfo.type;
 
     const departureTime = route
-      ? route.departureFrom(edge.from, edge.tripIndex).toString()
-      : 'N/A';
+      .departureFrom(edge.stopIndex, edge.tripIndex)
+      .toString();
     const arrivalTime = edge.arrival.toString();
 
     const escapedRouteName = this.escapeDotString(routeName);
@@ -138,10 +329,10 @@ export class Plotter {
    * Creates a transfer edge with transfer information oval in the middle.
    */
   private createTransferEdge(edge: TransferEdge, round: number): string[] {
-    const fromNodeId = `s_${edge.from}`;
-    const toNodeId = `s_${edge.to}`;
+    const fromNodeId = this.stationNodeId(edge.from);
+    const toNodeId = this.stationNodeId(edge.to);
     const roundColor = this.getRoundColor(round);
-    const transferOvalId = `e_${edge.from}_${edge.to}_${round}`;
+    const transferOvalId = this.transferEdgeNodeId(edge.from, edge.to, round);
 
     const transferTime = edge.minTransferTime?.toString() || 'N/A';
     const escapedTransferTime = this.escapeDotString(transferTime);
@@ -162,10 +353,20 @@ export class Plotter {
     toEdge: VehicleEdge,
     round: number,
   ): string[] {
-    const fromStationId = `s_${fromEdge.to}`;
-    const toStationId = `s_${toEdge.from}`;
+    const fromStopId = this.getVehicleEdgeToStopId(fromEdge);
+    const toStopId = this.getVehicleEdgeFromStopId(toEdge);
+    if (!fromStopId || !toStopId) {
+      return [];
+    }
+
+    const fromStationId = this.stationNodeId(fromStopId);
+    const toStationId = this.stationNodeId(toStopId);
     const roundColor = this.getRoundColor(round);
-    const continuationOvalId = `continuation_${fromEdge.to}_${toEdge.from}_${round}`;
+    const continuationOvalId = this.continuationNodeId(
+      fromStopId,
+      toStopId,
+      round,
+    );
 
     const fromRoute = this.result.timetable.getRoute(fromEdge.routeId);
     const toRoute = this.result.timetable.getRoute(toEdge.routeId);
@@ -187,7 +388,7 @@ export class Plotter {
 
     const fromArrivalTime = fromEdge.arrival.toString();
     const toDepartureTime = toRoute
-      ? toRoute.departureFrom(toEdge.from, toEdge.tripIndex).toString()
+      ? toRoute.departureFrom(toEdge.stopIndex, toEdge.tripIndex).toString()
       : 'N/A';
 
     const escapedFromRouteName = this.escapeDotString(fromRouteName);
@@ -200,102 +401,121 @@ export class Plotter {
 
     const ovalLabel = `${escapedFromRouteType} ${escapedFromRouteName} (${fromRouteInfo}) ${fromArrivalTime}\\n↓\\n${escapedToRouteType} ${escapedToRouteName} (${toRouteInfo}) ${toDepartureTime}`;
 
+    const { continuationFill } = DOT_CONFIG.colors;
+    const { continuation: penWidth, continuationEdge: edgePenWidth } =
+      DOT_CONFIG.penWidth;
+
     return [
-      `  "${continuationOvalId}" [label="${ovalLabel}" shape=oval style="filled,bold" fillcolor="#ffffcc" color="${roundColor}" penwidth="2"];`,
-      `  "${fromStationId}" -> "${continuationOvalId}" [color="${roundColor}" style="bold" penwidth="3"];`,
-      `  "${continuationOvalId}" -> "${toStationId}" [color="${roundColor}" style="bold" penwidth="3"];`,
+      `  "${continuationOvalId}" [label="${ovalLabel}" shape=oval style="filled,bold" fillcolor="${continuationFill}" color="${roundColor}" penwidth="${penWidth}"];`,
+      `  "${fromStationId}" -> "${continuationOvalId}" [color="${roundColor}" style="bold" penwidth="${edgePenWidth}"];`,
+      `  "${continuationOvalId}" -> "${toStationId}" [color="${roundColor}" style="bold" penwidth="${edgePenWidth}"];`,
     ];
   }
 
   /**
-   * Collects all stations and edges for the graph.
+   * Collects all stations that appear in the routing graph.
    */
-  private collectGraphData(): {
-    stations: Set<StopId>;
-    edges: string[];
-  } {
+  private collectStations(): Set<StopId> {
     const stations = new Set<StopId>();
+    const graph = this.result.routingState.graph;
+
+    for (const roundMap of graph) {
+      for (const [stopId, edge] of roundMap) {
+        stations.add(stopId);
+
+        if (isVehicleEdge(edge)) {
+          const fromStopId = this.getVehicleEdgeFromStopId(edge);
+          const toStopId = this.getVehicleEdgeToStopId(edge);
+          if (fromStopId) stations.add(fromStopId);
+          if (toStopId) stations.add(toStopId);
+        }
+      }
+    }
+
+    return stations;
+  }
+
+  /**
+   * Collects all continuation edges from a vehicle edge chain.
+   */
+  private collectContinuationChain(edge: VehicleEdge, round: number): string[] {
+    const continuationEdges: string[] = [];
+    let currentEdge = edge;
+    let previousEdge = edge.continuationOf;
+
+    while (previousEdge) {
+      const edgeParts = this.createContinuationEdge(
+        previousEdge,
+        currentEdge,
+        round,
+      );
+      continuationEdges.push(...edgeParts);
+
+      currentEdge = previousEdge;
+      previousEdge = previousEdge.continuationOf;
+    }
+
+    return continuationEdges;
+  }
+
+  /**
+   * Collects all edges for the routing graph.
+   */
+  private collectEdges(): string[] {
     const edges: string[] = [];
     const continuationEdges: string[] = [];
-    const graph: Map<StopId, RoutingEdge>[] = this.result.routingState.graph;
+    const graph = this.result.routingState.graph;
 
-    // Collect all stops that appear in the graph
-    graph.forEach((roundMap) => {
-      roundMap.forEach((edge, stopId) => {
-        stations.add(stopId);
-        if ('from' in edge && 'to' in edge) {
-          stations.add(edge.from);
-          stations.add(edge.to);
-        }
-      });
-    });
+    for (let round = 0; round < graph.length; round++) {
+      const roundMap = graph[round];
+      if (!roundMap) continue;
 
-    // Create edges for each round
-    graph.forEach((roundMap, round) => {
+      // Skip round 0 as it contains only origin nodes
       if (round === 0) {
-        // Skip round 0 as it contains only origin nodes
-        return;
+        continue;
       }
 
-      roundMap.forEach((edge) => {
-        if ('from' in edge && 'to' in edge) {
-          if ('routeId' in edge) {
-            const vehicleEdgeParts = this.createVehicleEdge(edge, round);
-            edges.push(...vehicleEdgeParts);
-            if (edge.continuationOf) {
-              let currentEdge = edge;
-              let previousEdge: VehicleEdge | undefined = edge.continuationOf;
+      for (const edge of roundMap.values()) {
+        if (isVehicleEdge(edge)) {
+          edges.push(...this.createVehicleEdge(edge, round));
 
-              while (previousEdge) {
-                const continuationEdgeParts = this.createContinuationEdge(
-                  previousEdge,
-                  currentEdge,
-                  round,
-                );
-                continuationEdges.push(...continuationEdgeParts);
-
-                currentEdge = previousEdge;
-                previousEdge = previousEdge.continuationOf;
-              }
-            }
-          } else {
-            const transferEdgeParts = this.createTransferEdge(edge, round);
-            edges.push(...transferEdgeParts);
+          if (edge.continuationOf) {
+            continuationEdges.push(
+              ...this.collectContinuationChain(edge, round),
+            );
           }
+        } else if (isTransferEdge(edge)) {
+          edges.push(...this.createTransferEdge(edge, round));
         }
-      });
-    });
-    edges.push(...continuationEdges);
+      }
+    }
 
-    return { stations, edges };
+    return [...edges, ...continuationEdges];
   }
 
   /**
    * Plots the routing graph as a DOT graph for visualization.
+   *
+   * @returns A string containing the DOT graph representation.
    */
   plotDotGraph(): string {
-    const { stations, edges } = this.collectGraphData();
+    const stations = this.collectStations();
+    const edges = this.collectEdges();
 
-    const dotParts = [
-      'digraph RoutingGraph {',
-      '  graph [overlap=false, splines=true, rankdir=TB, bgcolor=white, nodesep=0.8, ranksep=1.2, concentrate=true];',
-      '  node [fontname="Arial" margin=0.1];',
-      '  edge [fontname="Arial" fontsize=10];',
-      '',
-      '  // Stations',
-    ];
+    const builder = new DotBuilder();
+    builder.addHeader();
+    builder.addComment('Stations');
 
-    stations.forEach((stopId) => {
+    for (const stopId of stations) {
       const stationNode = this.createStationNode(stopId);
       if (stationNode) {
-        dotParts.push(stationNode);
+        builder.addRaw([stationNode]);
       }
-    });
+    }
 
-    dotParts.push('', '  // Edges');
-    dotParts.push(...edges);
+    builder.addComment('Edges');
+    builder.addRaw(edges);
 
-    dotParts.push('}');
-    return dotParts.join('\n');
+    return builder.build();
   }
 }

--- a/src/routing/query.ts
+++ b/src/routing/query.ts
@@ -3,16 +3,18 @@ import { Duration } from '../timetable/duration.js';
 import { Time } from '../timetable/time.js';
 import { ALL_TRANSPORT_MODES, RouteType } from '../timetable/timetable.js';
 
+export type QueryOptions = {
+  maxTransfers: number;
+  minTransferTime: Duration;
+  transportModes: Set<RouteType>;
+};
+
 export class Query {
   from: SourceStopId;
   to: Set<SourceStopId>;
   departureTime: Time;
   lastDepartureTime?: Time;
-  options: {
-    maxTransfers: number;
-    minTransferTime: Duration;
-    transportModes: Set<RouteType>;
-  };
+  options: QueryOptions;
 
   constructor(builder: typeof Query.Builder.prototype) {
     this.from = builder.fromValue;

--- a/src/routing/result.ts
+++ b/src/routing/result.ts
@@ -95,6 +95,7 @@ export class Result {
     const route: Leg[] = [];
     let currentStop = fastestDestination;
     let round = fastestTime.legNumber;
+    let previousVehicleEdge: VehicleEdge | undefined;
     while (round > 0) {
       const edge = this.routingState.graph[round]?.get(currentStop);
       if (!edge) {
@@ -112,8 +113,32 @@ export class Result {
           vehicleEdge = vehicleEdge.continuationOf;
         }
         leg = this.buildVehicleLeg(chainedEdges);
+        // Insert a guaranteed transfer leg between consecutive vehicle legs if applicable
+        if (
+          previousVehicleEdge &&
+          this.timetable.isTripTransferGuaranteed(
+            {
+              stopIndex: vehicleEdge.hopOffStopIndex,
+              routeId: vehicleEdge.routeId,
+              tripIndex: vehicleEdge.tripIndex,
+            },
+            {
+              stopIndex: previousVehicleEdge.stopIndex,
+              routeId: previousVehicleEdge.routeId,
+              tripIndex: previousVehicleEdge.tripIndex,
+            },
+          )
+        ) {
+          const guaranteedTransferLeg = this.buildGuaranteedTransferLeg(
+            vehicleEdge,
+            previousVehicleEdge,
+          );
+          route.unshift(guaranteedTransferLeg);
+        }
+        previousVehicleEdge = vehicleEdge;
       } else if ('type' in edge) {
         leg = this.buildTransferLeg(edge);
+        previousVehicleEdge = undefined;
       } else {
         break;
       }
@@ -147,21 +172,28 @@ export class Result {
     const lastRoute = this.timetable.getRoute(lastEdge.routeId)!;
     return {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      from: this.stopsIndex.findStopById(firstRoute.stopId(firstEdge.from))!,
+      from: this.stopsIndex.findStopById(
+        firstRoute.stopId(firstEdge.stopIndex),
+      )!,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      to: this.stopsIndex.findStopById(lastRoute.stopId(lastEdge.to))!,
+      to: this.stopsIndex.findStopById(
+        lastRoute.stopId(lastEdge.hopOffStopIndex),
+      )!,
       // The route info comes from the first boarded route in case on continuous trips
       route: this.timetable.getServiceRouteInfo(firstRoute),
       departureTime: firstRoute.departureFrom(
-        firstEdge.from,
+        firstEdge.stopIndex,
         firstEdge.tripIndex,
       ),
       arrivalTime: lastEdge.arrival,
       pickUpType: firstRoute.pickUpTypeFrom(
-        firstEdge.from,
+        firstEdge.stopIndex,
         firstEdge.tripIndex,
       ),
-      dropOffType: lastRoute.dropOffTypeAt(lastEdge.to, lastEdge.tripIndex),
+      dropOffType: lastRoute.dropOffTypeAt(
+        lastEdge.hopOffStopIndex,
+        lastEdge.tripIndex,
+      ),
     };
   }
 
@@ -179,6 +211,33 @@ export class Result {
       to: this.stopsIndex.findStopById(edge.to)!,
       minTransferTime: edge.minTransferTime,
       type: edge.type,
+    };
+  }
+
+  /**
+   * Builds a guaranteed transfer leg between two consecutive vehicle legs.
+   *
+   * @param fromEdge The vehicle edge we're alighting from
+   * @param toEdge The vehicle edge we're boarding
+   * @returns A transfer leg with type 'GUARANTEED'
+   */
+  private buildGuaranteedTransferLeg(
+    fromEdge: VehicleEdge,
+    toEdge: VehicleEdge,
+  ): Transfer {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const fromRoute = this.timetable.getRoute(fromEdge.routeId)!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const toRoute = this.timetable.getRoute(toEdge.routeId)!;
+    const fromStopId = fromRoute.stopId(fromEdge.hopOffStopIndex);
+    const toStopId = toRoute.stopId(toEdge.stopIndex);
+
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      from: this.stopsIndex.findStopById(fromStopId)!,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      to: this.stopsIndex.findStopById(toStopId)!,
+      type: 'GUARANTEED',
     };
   }
 

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -62,7 +62,7 @@ export class Route {
    * @throws If no vehicle leg is found in the route.
    */
   departureTime(): Time {
-    const cumulativeTransferTime: Duration = Duration.zero();
+    const cumulativeTransferTime: Duration = Duration.ZERO;
     for (let i = 0; i < this.legs.length; i++) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const leg = this.legs[i]!;
@@ -83,8 +83,8 @@ export class Route {
    * @throws If no vehicle leg is found in the route.
    */
   arrivalTime(): Time {
-    let lastVehicleArrivalTime: Time = Time.origin();
-    const totalTransferTime: Duration = Duration.zero();
+    let lastVehicleArrivalTime: Time = Time.ORIGIN;
+    const totalTransferTime: Duration = Duration.ZERO;
     let vehicleLegFound = false;
 
     for (let i = this.legs.length - 1; i >= 0; i--) {
@@ -116,7 +116,7 @@ export class Route {
    * @returns The total duration of the route.
    */
   totalDuration(): Duration {
-    if (this.legs.length === 0) return Duration.zero();
+    if (this.legs.length === 0) return Duration.ZERO;
     return this.arrivalTime().diff(this.departureTime());
   }
 
@@ -131,8 +131,8 @@ export class Route {
         const fromStop = `From: ${leg.from.name}${leg.from.platform ? ` (Pl. ${leg.from.platform})` : ''}`;
         const toStop = `To: ${leg.to.name}${leg.to.platform ? ` (Pl. ${leg.to.platform})` : ''}`;
         const transferDetails =
-          'minTransferTime' in leg
-            ? `Minimum Transfer Time: ${leg.minTransferTime?.toString()}`
+          'type' in leg && !('route' in leg)
+            ? `Transfer: ${leg.type}${leg.minTransferTime ? `, Minimum Transfer Time: ${leg.minTransferTime.toString()}` : ''}`
             : '';
         const travelDetails =
           'route' in leg && 'departureTime' in leg && 'arrivalTime' in leg

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -2,31 +2,19 @@
 import { StopId } from '../stops/stops.js';
 import { StopsIndex } from '../stops/stopsIndex.js';
 import { Duration } from '../timetable/duration.js';
-import {
-  Route,
-  RouteId,
-  StopRouteIndex,
-  TripRouteIndex,
-} from '../timetable/route.js';
+import { Route, StopRouteIndex, TripRouteIndex } from '../timetable/route.js';
 import { Time } from '../timetable/time.js';
-import {
-  Timetable,
-  TransferType,
-  TripBoarding,
-} from '../timetable/timetable.js';
-import { Query } from './query.js';
+import { Timetable, TransferType, TripStop } from '../timetable/timetable.js';
+import { Query, QueryOptions } from './query.js';
 import { Result } from './result.js';
 
-const UNREACHED = Time.infinity();
+const UNREACHED = Time.INFINITY;
 
 export type OriginNode = { arrival: Time };
 
-export type VehicleEdge = {
+export type VehicleEdge = TripStop & {
   arrival: Time;
-  from: StopRouteIndex;
-  to: StopRouteIndex;
-  routeId: RouteId;
-  tripIndex: TripRouteIndex;
+  hopOffStopIndex: StopRouteIndex;
   continuationOf?: VehicleEdge;
 };
 export type TransferEdge = {
@@ -38,7 +26,7 @@ export type TransferEdge = {
 };
 export type RoutingEdge = OriginNode | VehicleEdge | TransferEdge;
 
-type TripContinuation = TripBoarding & {
+type TripContinuation = TripStop & {
   previousEdge: VehicleEdge;
 };
 
@@ -107,6 +95,7 @@ export class Router {
           hopOnStopIndex,
           round,
           routingState,
+          query.options,
         );
         for (const newStop of newlyMarkedStops) {
           markedStops.add(newStop);
@@ -123,9 +112,10 @@ export class Router {
           const route = this.timetable.getRoute(continuation.routeId)!;
           const routeScanResults = this.scanRoute(
             route,
-            continuation.hopOnStopIndex,
+            continuation.stopIndex,
             round,
             routingState,
+            query.options,
             continuation,
           );
           for (const newStop of routeScanResults) {
@@ -171,7 +161,7 @@ export class Router {
       if (!arrival || !('routeId' in arrival)) continue;
 
       const continuousTrips = this.timetable.getContinuousTrips(
-        arrival.to,
+        arrival.hopOffStopIndex,
         arrival.routeId,
         arrival.tripIndex,
       );
@@ -179,7 +169,7 @@ export class Router {
         const trip = continuousTrips[i]!;
         continuations.push({
           routeId: trip.routeId,
-          hopOnStopIndex: trip.hopOnStopIndex,
+          stopIndex: trip.stopIndex,
           tripIndex: trip.tripIndex,
           previousEdge: arrival,
         });
@@ -247,13 +237,14 @@ export class Router {
     hopOnStopIndex: StopRouteIndex,
     round: Round,
     routingState: RoutingState,
+    options: QueryOptions,
     tripContinuation?: TripContinuation,
   ): Set<StopId> {
     const newlyMarkedStops = new Set<StopId>();
-    let activeTrip: TripBoarding | undefined = tripContinuation
+    let activeTrip: TripStop | undefined = tripContinuation
       ? {
           routeId: route.id,
-          hopOnStopIndex,
+          stopIndex: hopOnStopIndex,
           tripIndex: tripContinuation.tripIndex,
         }
       : undefined;
@@ -288,13 +279,13 @@ export class Router {
           arrivalTime.isBefore(earliestArrivalAtCurrentStop) &&
           arrivalTime.isBefore(earliestArrivalAtAnyDestination)
         ) {
-          const edge = {
-            arrival: arrivalTime,
-            routeId: route.id,
+          const edge: VehicleEdge = {
+            routeId: activeTrip.routeId,
+            stopIndex: activeTrip.stopIndex,
             tripIndex: activeTrip.tripIndex,
-            from: activeTrip.hopOnStopIndex,
-            to: currentStopIndex,
-          } as VehicleEdge;
+            arrival: arrivalTime,
+            hopOffStopIndex: currentStopIndex,
+          };
           if (tripContinuation) {
             // In case of continuous trip, we set a pointer to the previous edge
             edge.continuationOf = tripContinuation.previousEdge;
@@ -314,12 +305,8 @@ export class Router {
       }
       // check if we can board an earlier trip at the current stop
       // if there was no current trip, find the first one reachable
-      const earliestArrivalOnPreviousRound =
-        edgesAtPreviousRound.get(currentStop)?.arrival;
-      // TODO if the last edge is not a transfer, and if there is no trip continuation of type 1 (guaranteed)
-      // Add the minTransferTime to make sure there's at least 2 minutes to transfer.
-      // If platforms are collapsed, make sure to apply the station level transfer time
-      // (or later at route reconstruction time)
+      const previousEdge = edgesAtPreviousRound.get(currentStop);
+      const earliestArrivalOnPreviousRound = previousEdge?.arrival;
       if (
         earliestArrivalOnPreviousRound !== undefined &&
         (activeTrip === undefined ||
@@ -335,16 +322,87 @@ export class Router {
           earliestArrivalOnPreviousRound,
           activeTrip?.tripIndex,
         );
-        if (earliestTrip !== undefined) {
+        if (earliestTrip === undefined) {
+          continue;
+        }
+
+        const firstBoardableTrip = this.findFirstBoardableTrip(
+          currentStopIndex,
+          route,
+          earliestTrip,
+          earliestArrivalOnPreviousRound,
+          activeTrip?.tripIndex,
+          // provide the previous trip if the previous edge was a vehicle
+          previousEdge && 'routeId' in previousEdge ? previousEdge : undefined,
+          options.minTransferTime,
+        );
+
+        if (firstBoardableTrip !== undefined) {
           activeTrip = {
             routeId: route.id,
-            tripIndex: earliestTrip,
-            hopOnStopIndex: currentStopIndex,
+            tripIndex: firstBoardableTrip,
+            stopIndex: currentStopIndex,
           };
         }
       }
     }
     return newlyMarkedStops;
+  }
+
+  /**
+   * Finds the first boardable trip on a route at a given stop that meets transfer requirements.
+   *
+   * This method searches through trips on a route starting from the earliest trip index reachable
+   * from the previous edge to find the first trip that can be effectively boarded,
+   * considering pickup availability, transfer guarantees, and minimum transfer times.
+   *
+   * @param stopIndex The index in the route of the stop where boarding is attempted
+   * @param route The route to search for boardable trips
+   * @param earliestTrip The earliest trip index to start searching from
+   * @param after The earliest time after which boarding can occur
+   * @param beforeTrip Optional upper bound trip index to limit search
+   * @param previousTrip The previous trip taken (for transfer guarantee checks)
+   * @param transferTime Minimum time required for transfers between trips
+   * @returns The trip index of the first boardable trip, or undefined if none found
+   */
+  private findFirstBoardableTrip(
+    stopIndex: StopRouteIndex,
+    route: Route,
+    earliestTrip: TripRouteIndex,
+    after: Time = Time.ORIGIN,
+    beforeTrip?: TripRouteIndex,
+    previousTrip?: VehicleEdge,
+    transferTime: Duration = Duration.ZERO,
+  ): TripRouteIndex | undefined {
+    const nbTrips = route.getNbTrips();
+
+    for (let t = earliestTrip; t < (beforeTrip ?? nbTrips); t++) {
+      const pickup = route.pickUpTypeFrom(stopIndex, t);
+      if (pickup === 'NOT_AVAILABLE') {
+        continue;
+      }
+      if (previousTrip === undefined) {
+        return t;
+      }
+
+      const isGuaranteed = this.timetable.isTripTransferGuaranteed(
+        {
+          stopIndex: previousTrip.hopOffStopIndex,
+          routeId: previousTrip.routeId,
+          tripIndex: previousTrip.tripIndex,
+        },
+        { stopIndex, routeId: route.id, tripIndex: t },
+      );
+      if (isGuaranteed) {
+        return t;
+      }
+      const departure = route.departureFrom(stopIndex, t);
+      const requiredTime = after.plus(transferTime);
+      if (!departure.isBefore(requiredTime)) {
+        return t;
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -378,7 +436,7 @@ export class Router {
           transferTime = transfer.minTransferTime;
         } else if (transfer.type === 'IN_SEAT') {
           // TODO not needed anymore now that trip continuations are handled separately
-          transferTime = Duration.zero();
+          transferTime = Duration.ZERO;
         } else {
           transferTime = options.minTransferTime;
         }
@@ -393,7 +451,7 @@ export class Router {
             to: transfer.destination,
             minTransferTime: transfer.minTransferTime,
             type: transfer.type,
-          });
+          } as TransferEdge);
           routingState.earliestArrivals.set(transfer.destination, {
             arrival: arrivalAfterTransfer,
             legNumber: round,

--- a/src/timetable/__tests__/io.test.ts
+++ b/src/timetable/__tests__/io.test.ts
@@ -6,16 +6,16 @@ import {
   deserializeRoutesAdjacency,
   deserializeServiceRoutesMap,
   deserializeStopsAdjacency,
-  deserializeTripContinuations,
+  deserializeTripTransfers,
   serializeRoutesAdjacency,
   serializeServiceRoutesMap,
   serializeStopsAdjacency,
-  serializeTripContinuations,
+  serializeTripTransfers,
 } from '../io.js';
 import { REGULAR, Route } from '../route.js';
 import { Time } from '../time.js';
-import { ServiceRoute, StopAdjacency, TripBoarding } from '../timetable.js';
-import { encode } from '../tripBoardingId.js';
+import { ServiceRoute, StopAdjacency, TripStop } from '../timetable.js';
+import { encode } from '../tripStopId.js';
 
 describe('Timetable IO', () => {
   const stopsAdjacency: StopAdjacency[] = [
@@ -119,17 +119,17 @@ describe('Timetable IO', () => {
   });
 
   it('should serialize and deserialize tripContinuations correctly', () => {
-    const tripContinuations = new Map<bigint, TripBoarding[]>();
+    const tripContinuations = new Map<bigint, TripStop[]>();
     tripContinuations.set(encode(1, 0, 2), [
-      { hopOnStopIndex: 1, routeId: 0, tripIndex: 2 },
-      { hopOnStopIndex: 3, routeId: 1, tripIndex: 1 },
+      { stopIndex: 1, routeId: 0, tripIndex: 2 },
+      { stopIndex: 3, routeId: 1, tripIndex: 1 },
     ]);
     tripContinuations.set(encode(2, 0, 0), [
-      { hopOnStopIndex: 2, routeId: 0, tripIndex: 0 },
+      { stopIndex: 2, routeId: 0, tripIndex: 0 },
     ]);
 
-    const serialized = serializeTripContinuations(tripContinuations);
-    const deserialized = deserializeTripContinuations(serialized);
+    const serialized = serializeTripTransfers(tripContinuations);
+    const deserialized = deserializeTripTransfers(serialized);
 
     assert.deepStrictEqual(deserialized, tripContinuations);
   });

--- a/src/timetable/__tests__/route.test.ts
+++ b/src/timetable/__tests__/route.test.ts
@@ -249,10 +249,10 @@ describe('Route', () => {
       assert.strictEqual(tripIndex, undefined);
     });
 
-    it('should skip trips where pickup is not available', () => {
+    it('should find earliest trip', () => {
       const tripIndex = route.findEarliestTrip(1);
-      // Trip 0 has NOT_AVAILABLE pickup at stop index 1, so should return trip 1
-      assert.strictEqual(tripIndex, 1);
+      // findEarliestTrip only filters by time, not pickup type
+      assert.strictEqual(tripIndex, 0);
     });
 
     it('should respect beforeTrip constraint', () => {
@@ -261,7 +261,7 @@ describe('Route', () => {
     });
 
     it('should return undefined when beforeTrip is 0', () => {
-      const tripIndex = route.findEarliestTrip(0, Time.origin(), 0);
+      const tripIndex = route.findEarliestTrip(0, Time.ORIGIN, 0);
       assert.strictEqual(tripIndex, undefined);
     });
 

--- a/src/timetable/__tests__/time.test.ts
+++ b/src/timetable/__tests__/time.test.ts
@@ -8,20 +8,20 @@ describe('Time', () => {
   describe('Static factory methods', () => {
     describe('infinity()', () => {
       it('should return a Time instance representing infinity', () => {
-        const infinityTime = Time.infinity();
+        const infinityTime = Time.INFINITY;
         assert.strictEqual(infinityTime.toMinutes(), Number.MAX_SAFE_INTEGER);
       });
 
       it('should return the same infinity value for multiple calls', () => {
-        const infinity1 = Time.infinity();
-        const infinity2 = Time.infinity();
+        const infinity1 = Time.INFINITY;
+        const infinity2 = Time.INFINITY;
         assert(infinity1.equals(infinity2));
       });
     });
 
     describe('origin()', () => {
       it('should return a Time instance representing midnight (0 minutes)', () => {
-        const midnight = Time.origin();
+        const midnight = Time.ORIGIN;
         assert.strictEqual(midnight.toMinutes(), 0);
         assert.strictEqual(midnight.toString(), '00:00');
       });
@@ -236,7 +236,7 @@ describe('Time', () => {
       });
 
       it('should return 0 for midnight', () => {
-        const time = Time.origin();
+        const time = Time.ORIGIN;
         assert.strictEqual(time.toMinutes(), 0);
       });
     });
@@ -411,7 +411,7 @@ describe('Time', () => {
 
       it('should handle infinity time', () => {
         const time1 = Time.fromMinutes(120);
-        const infinity = Time.infinity();
+        const infinity = Time.INFINITY;
         const maxTime = Time.max(time1, infinity);
         assert.strictEqual(maxTime, infinity);
       });
@@ -448,7 +448,7 @@ describe('Time', () => {
 
       it('should handle origin time', () => {
         const time1 = Time.fromMinutes(120);
-        const origin = Time.origin();
+        const origin = Time.ORIGIN;
         const minTime = Time.min(time1, origin);
         assert.strictEqual(minTime, origin);
       });
@@ -484,7 +484,7 @@ describe('Time', () => {
 
     it('should handle comparison with infinity', () => {
       const normalTime = Time.fromMinutes(1000);
-      const infinity = Time.infinity();
+      const infinity = Time.INFINITY;
 
       assert.strictEqual(normalTime.isBefore(infinity), true);
       assert.strictEqual(infinity.isAfter(normalTime), true);

--- a/src/timetable/__tests__/timetable.test.ts
+++ b/src/timetable/__tests__/timetable.test.ts
@@ -9,9 +9,9 @@ import {
   ServiceRoute,
   StopAdjacency,
   Timetable,
-  TripBoarding,
+  TripStop,
 } from '../timetable.js';
-import { encode } from '../tripBoardingId.js';
+import { encode } from '../tripStopId.js';
 
 describe('Timetable', () => {
   const stopsAdjacency: StopAdjacency[] = [
@@ -101,6 +101,7 @@ describe('Timetable', () => {
     routesAdjacency,
     routes,
     new Map(),
+    new Map(),
   );
 
   it('should serialize a timetable to a Uint8Array', () => {
@@ -135,12 +136,6 @@ describe('Timetable', () => {
     const afterTime = Time.fromHMS(23, 40, 0);
     const tripIndex = route.findEarliestTrip(0, afterTime);
     assert.strictEqual(tripIndex, undefined);
-  });
-  it('should return undefined if the stop on a trip has pick up not available', () => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const route = sampleTimetable.getRoute(0)!;
-    const tripIndex = route.findEarliestTrip(1);
-    assert.strictEqual(tripIndex, 1);
   });
   describe('findReachableRoutes', () => {
     it('should find reachable routes from a single stop', () => {
@@ -248,7 +243,7 @@ describe('Timetable', () => {
       it('should return empty array when stop has trip continuations but not for the specified trip', () => {
         // Create a timetable with trip continuations that don't match the query
         const tripContinuationsMap = new Map([
-          [encode(0, 0, 1), [{ hopOnStopIndex: 0, routeId: 1, tripIndex: 0 }]], // Different trip index
+          [encode(0, 0, 1), [{ stopIndex: 0, routeId: 1, tripIndex: 0 }]], // Different trip index
         ]);
 
         const stopsWithContinuations: StopAdjacency[] = [
@@ -275,9 +270,9 @@ describe('Timetable', () => {
       });
 
       it('should return trip continuations when they exist for the specified trip', () => {
-        const expectedContinuations: TripBoarding[] = [
-          { hopOnStopIndex: 0, routeId: 1, tripIndex: 0 },
-          { hopOnStopIndex: 0, routeId: 1, tripIndex: 1 },
+        const expectedContinuations: TripStop[] = [
+          { stopIndex: 0, routeId: 1, tripIndex: 0 },
+          { stopIndex: 0, routeId: 1, tripIndex: 1 },
         ];
 
         const tripContinuationsMap = new Map([
@@ -310,6 +305,355 @@ describe('Timetable', () => {
       it('should return empty array when querying with non-matching parameters', () => {
         const continuousTrips = sampleTimetable.getContinuousTrips(999, 0, 0);
         assert.deepStrictEqual(continuousTrips, []);
+      });
+    });
+
+    describe('getGuaranteedTripTransfers', () => {
+      it('should return empty array when stop has no guaranteed trip transfers', () => {
+        const guaranteedTransfers = sampleTimetable.getGuaranteedTripTransfers(
+          0,
+          0,
+          0,
+        );
+        assert.deepStrictEqual(guaranteedTransfers, []);
+      });
+
+      it('should return empty array when stop has guaranteed trip transfers but not for the specified trip', () => {
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 1), [{ stopIndex: 0, routeId: 1, tripIndex: 0 }]], // Different trip index
+        ]);
+
+        const stopsWithGuaranteedTransfers: StopAdjacency[] = [
+          { routes: [] },
+          {
+            routes: [0, 1],
+          },
+          { routes: [1] },
+        ];
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsWithGuaranteedTransfers,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const guaranteedTransfers =
+          timetableWithGuaranteedTransfers.getGuaranteedTripTransfers(0, 0, 0); // Query trip index 0, but transfers are for trip index 1
+        assert.deepStrictEqual(guaranteedTransfers, []);
+      });
+
+      it('should return guaranteed trip transfers when they exist for the specified trip', () => {
+        const expectedTransfers: TripStop[] = [
+          { stopIndex: 0, routeId: 1, tripIndex: 0 },
+          { stopIndex: 0, routeId: 1, tripIndex: 1 },
+        ];
+
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 0), expectedTransfers],
+        ]);
+
+        const stopsWithGuaranteedTransfers: StopAdjacency[] = [
+          { routes: [] },
+          {
+            routes: [0, 1],
+          },
+          { routes: [1] },
+        ];
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsWithGuaranteedTransfers,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const guaranteedTransfers =
+          timetableWithGuaranteedTransfers.getGuaranteedTripTransfers(0, 0, 0);
+        assert.deepStrictEqual(guaranteedTransfers, expectedTransfers);
+      });
+
+      it('should return empty array when querying with non-matching parameters', () => {
+        const guaranteedTransfers = sampleTimetable.getGuaranteedTripTransfers(
+          999,
+          0,
+          0,
+        );
+        assert.deepStrictEqual(guaranteedTransfers, []);
+      });
+    });
+
+    describe('isTripTransferGuaranteed', () => {
+      it('should return false when no guaranteed transfers exist', () => {
+        const fromTripStop: TripStop = {
+          stopIndex: 0,
+          routeId: 0,
+          tripIndex: 0,
+        };
+        const toTripStop: TripStop = { stopIndex: 0, routeId: 1, tripIndex: 0 };
+
+        const result = sampleTimetable.isTripTransferGuaranteed(
+          fromTripStop,
+          toTripStop,
+        );
+        assert.strictEqual(result, false);
+      });
+
+      it('should return false when guaranteed transfers exist but not for the specified trip', () => {
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 1), [{ stopIndex: 0, routeId: 1, tripIndex: 0 }]], // Transfers for trip index 1
+        ]);
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsAdjacency,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const fromTripStop: TripStop = {
+          stopIndex: 0,
+          routeId: 0,
+          tripIndex: 0,
+        }; // Query trip index 0
+        const toTripStop: TripStop = { stopIndex: 0, routeId: 1, tripIndex: 0 };
+
+        const result =
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            toTripStop,
+          );
+        assert.strictEqual(result, false);
+      });
+
+      it('should return true when the transfer is guaranteed', () => {
+        const guaranteedTransfer: TripStop = {
+          stopIndex: 0,
+          routeId: 1,
+          tripIndex: 0,
+        };
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 0), [guaranteedTransfer]],
+        ]);
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsAdjacency,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const fromTripStop: TripStop = {
+          stopIndex: 0,
+          routeId: 0,
+          tripIndex: 0,
+        };
+        const toTripStop: TripStop = { stopIndex: 0, routeId: 1, tripIndex: 0 };
+
+        const result =
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            toTripStop,
+          );
+        assert.strictEqual(result, true);
+      });
+
+      it('should return false when transfer destination does not match any guaranteed transfer', () => {
+        const guaranteedTransfer: TripStop = {
+          stopIndex: 0,
+          routeId: 1,
+          tripIndex: 0,
+        };
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 0), [guaranteedTransfer]],
+        ]);
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsAdjacency,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const fromTripStop: TripStop = {
+          stopIndex: 0,
+          routeId: 0,
+          tripIndex: 0,
+        };
+        const nonMatchingToTripStop: TripStop = {
+          stopIndex: 1,
+          routeId: 1,
+          tripIndex: 0,
+        }; // Different stopIndex
+
+        const result =
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            nonMatchingToTripStop,
+          );
+        assert.strictEqual(result, false);
+      });
+
+      it('should return true when transfer matches one of multiple guaranteed transfers', () => {
+        const guaranteedTransfers: TripStop[] = [
+          { stopIndex: 0, routeId: 1, tripIndex: 0 },
+          { stopIndex: 0, routeId: 1, tripIndex: 1 },
+          { stopIndex: 1, routeId: 1, tripIndex: 0 },
+        ];
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 0), guaranteedTransfers],
+        ]);
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsAdjacency,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const fromTripStop: TripStop = {
+          stopIndex: 0,
+          routeId: 0,
+          tripIndex: 0,
+        };
+
+        // Test matching the second guaranteed transfer
+        const toTripStop: TripStop = { stopIndex: 0, routeId: 1, tripIndex: 1 };
+        const result =
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            toTripStop,
+          );
+        assert.strictEqual(result, true);
+
+        // Test matching the third guaranteed transfer
+        const toTripStop2: TripStop = {
+          stopIndex: 1,
+          routeId: 1,
+          tripIndex: 0,
+        };
+        const result2 =
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            toTripStop2,
+          );
+        assert.strictEqual(result2, true);
+      });
+
+      it('should return false for invalid trip data (non-existent route)', () => {
+        const guaranteedTransfer: TripStop = {
+          stopIndex: 0,
+          routeId: 1,
+          tripIndex: 0,
+        };
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 0), [guaranteedTransfer]],
+        ]);
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsAdjacency,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const fromTripStop: TripStop = {
+          stopIndex: 0,
+          routeId: 999,
+          tripIndex: 0,
+        }; // Non-existent route
+        const toTripStop: TripStop = { stopIndex: 0, routeId: 1, tripIndex: 0 };
+
+        const result =
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            toTripStop,
+          );
+        assert.strictEqual(result, false);
+      });
+
+      it('should correctly distinguish between different stopIndex values', () => {
+        const guaranteedTransfer: TripStop = {
+          stopIndex: 0,
+          routeId: 1,
+          tripIndex: 0,
+        };
+        const guaranteedTripTransfersMap = new Map([
+          [encode(0, 0, 0), [guaranteedTransfer]],
+        ]);
+
+        const timetableWithGuaranteedTransfers = new Timetable(
+          stopsAdjacency,
+          routesAdjacency,
+          routes,
+          new Map(),
+          guaranteedTripTransfersMap,
+        );
+
+        const fromTripStop: TripStop = {
+          stopIndex: 0,
+          routeId: 0,
+          tripIndex: 0,
+        };
+
+        // Exact match should return true
+        const exactMatch: TripStop = { stopIndex: 0, routeId: 1, tripIndex: 0 };
+        assert.strictEqual(
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            exactMatch,
+          ),
+          true,
+        );
+
+        // Different stopIndex should return false
+        const differentStopIndex: TripStop = {
+          stopIndex: 1,
+          routeId: 1,
+          tripIndex: 0,
+        };
+        assert.strictEqual(
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            differentStopIndex,
+          ),
+          false,
+        );
+
+        // Different routeId should return false
+        const differentRouteId: TripStop = {
+          stopIndex: 0,
+          routeId: 0,
+          tripIndex: 0,
+        };
+        assert.strictEqual(
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            differentRouteId,
+          ),
+          false,
+        );
+
+        // Different tripIndex should return false
+        const differentTripIndex: TripStop = {
+          stopIndex: 0,
+          routeId: 1,
+          tripIndex: 1,
+        };
+        assert.strictEqual(
+          timetableWithGuaranteedTransfers.isTripTransferGuaranteed(
+            fromTripStop,
+            differentTripIndex,
+          ),
+          false,
+        );
       });
     });
   });

--- a/src/timetable/__tests__/tripBoardingId.test.ts
+++ b/src/timetable/__tests__/tripBoardingId.test.ts
@@ -8,7 +8,7 @@ import {
   getRouteId,
   getStopIndex,
   getTripIndex,
-} from '../tripBoardingId.js';
+} from '../tripStopId.js';
 
 describe('tripBoardingId', () => {
   it('should maintain identity for encode/decode round-trip', () => {

--- a/src/timetable/duration.ts
+++ b/src/timetable/duration.ts
@@ -1,4 +1,5 @@
 export class Duration {
+  public static ZERO = new Duration(0);
   private totalSeconds: number;
 
   private constructor(totalSeconds: number) {
@@ -21,14 +22,6 @@ export class Duration {
    */
   static fromMinutes(minutes: number): Duration {
     return new Duration(minutes * 60);
-  }
-  /**
-   * Gets a Duration instance representing zero duration (0 hours, 0 minutes, 0 seconds).
-   *
-   * @returns A Duration instance representing zero duration.
-   */
-  static zero(): Duration {
-    return new Duration(0);
   }
 
   /**

--- a/src/timetable/proto/timetable.proto
+++ b/src/timetable/proto/timetable.proto
@@ -40,17 +40,15 @@ message Transfer {
   optional uint32 minTransferTime = 3;
 }
 
-message TripBoarding {
-  uint32 hopOnStopIndex = 1;
+message TripStop {
+  uint32 stopIndex = 1;
   uint32 routeId = 2;
   uint32 tripIndex = 3;
 }
 
-message TripContinuationEntry {
-  uint32 originStopIndex = 1;
-  uint32 originRouteId = 2;
-  uint32 originTripIndex = 3;
-  repeated TripBoarding continuations = 4;
+message TripTransferEntry {
+  TripStop origin = 1;
+  repeated TripStop destinations = 2;
 }
 
 message StopAdjacency {
@@ -82,5 +80,6 @@ message Timetable {
   repeated StopAdjacency stopsAdjacency = 2;
   repeated Route routesAdjacency = 3;
   repeated ServiceRoute serviceRoutes = 4;
-  repeated TripContinuationEntry tripContinuations = 5;
+  repeated TripTransferEntry tripContinuations = 5;
+  repeated TripTransferEntry guaranteedTripTransfers = 6;
 }

--- a/src/timetable/route.ts
+++ b/src/timetable/route.ts
@@ -386,7 +386,7 @@ export class Route {
    */
   findEarliestTrip(
     stopIndex: StopRouteIndex,
-    after: Time = Time.origin(),
+    after: Time = Time.ORIGIN,
     beforeTrip?: TripRouteIndex,
   ): TripRouteIndex | undefined {
     if (this.nbTrips <= 0) return undefined;
@@ -408,14 +408,7 @@ export class Route {
       }
     }
     if (lb === -1) return undefined;
-
-    for (let t = lb; t < (beforeTrip ?? this.nbTrips); t++) {
-      const pickup = this.pickUpTypeFrom(stopIndex, t);
-      if (pickup !== 'NOT_AVAILABLE') {
-        return t;
-      }
-    }
-    return undefined;
+    return lb;
   }
 
   /**

--- a/src/timetable/time.ts
+++ b/src/timetable/time.ts
@@ -4,28 +4,13 @@ import { Duration } from './duration.js';
  * A class representing a time as minutes since midnight.
  */
 export class Time {
+  public static INFINITY = new Time(Number.MAX_SAFE_INTEGER);
+  public static ORIGIN = new Time(0);
   /*
    * Number of minutes since midnight.
    Note that this value can go beyond 3600 to model services overlapping with the next day.
    */
   private minutesSinceMidnight: number;
-  /**
-   * Gets the infinity time as a Time instance.
-   * This represents a time that is conceptually beyond any real possible time.
-   *
-   * @returns A Time instance representing an "infinity" time.
-   */
-  static infinity(): Time {
-    return new Time(Number.MAX_SAFE_INTEGER);
-  }
-  /**
-   * Gets the midnight time as a Time instance.
-   *
-   * @returns A Time instance representing midnight.
-   */
-  static origin(): Time {
-    return new Time(0);
-  }
 
   private constructor(minutes: number) {
     this.minutesSinceMidnight = minutes;

--- a/src/timetable/tripStopId.ts
+++ b/src/timetable/tripStopId.ts
@@ -10,7 +10,7 @@ const ROUTE_ID_SHIFT = BigInt(20);
 const STOP_INDEX_SHIFT = BigInt(40);
 
 // A TripId encodes a stop index, route ID, and trip index into a single bigint value
-export type TripBoardingId = bigint;
+export type TripStopId = bigint;
 
 /**
  * Validates that a value fits within 20 bits (0 to 1,048,575)
@@ -35,7 +35,7 @@ export const encode = (
   stopIndex: StopRouteIndex,
   routeId: RouteId,
   tripIndex: TripRouteIndex,
-): TripBoardingId => {
+): TripStopId => {
   validateValue(stopIndex, 'stopIndex');
   validateValue(routeId, 'routeId');
   validateValue(tripIndex, 'tripIndex');
@@ -49,46 +49,42 @@ export const encode = (
 
 /**
  * Decodes a trip boarding ID back into its constituent stop index, route ID, and trip index.
- * @param tripBoardingId - The encoded trip ID
+ * @param tripStopId - The encoded trip ID
  * @returns A tuple containing [stopIndex, routeId, tripIndex]
  */
 export const decode = (
-  tripBoardingId: TripBoardingId,
+  tripStopId: TripStopId,
 ): [StopRouteIndex, RouteId, TripRouteIndex] => {
-  const stopIndex = Number((tripBoardingId >> STOP_INDEX_SHIFT) & VALUE_MASK);
-  const routeId = Number((tripBoardingId >> ROUTE_ID_SHIFT) & VALUE_MASK);
-  const tripIndex = Number((tripBoardingId >> TRIP_INDEX_SHIFT) & VALUE_MASK);
+  const stopIndex = Number((tripStopId >> STOP_INDEX_SHIFT) & VALUE_MASK);
+  const routeId = Number((tripStopId >> ROUTE_ID_SHIFT) & VALUE_MASK);
+  const tripIndex = Number((tripStopId >> TRIP_INDEX_SHIFT) & VALUE_MASK);
 
   return [stopIndex, routeId, tripIndex];
 };
 
 /**
  * Extracts just the stop index from a trip ID without full decoding.
- * @param tripBoardingId - The encoded trip boarding ID
+ * @param tripStopId - The encoded trip boarding ID
  * @returns The stop index
  */
-export const getStopIndex = (
-  tripBoardingId: TripBoardingId,
-): StopRouteIndex => {
-  return Number((tripBoardingId >> STOP_INDEX_SHIFT) & VALUE_MASK);
+export const getStopIndex = (tripStopId: TripStopId): StopRouteIndex => {
+  return Number((tripStopId >> STOP_INDEX_SHIFT) & VALUE_MASK);
 };
 
 /**
  * Extracts just the route ID from a trip ID without full decoding.
- * @param tripBoardingId - The encoded trip boarding ID
+ * @param tripStopId - The encoded trip boarding ID
  * @returns The route ID
  */
-export const getRouteId = (tripBoardingId: TripBoardingId): RouteId => {
-  return Number((tripBoardingId >> ROUTE_ID_SHIFT) & VALUE_MASK);
+export const getRouteId = (tripStopId: TripStopId): RouteId => {
+  return Number((tripStopId >> ROUTE_ID_SHIFT) & VALUE_MASK);
 };
 
 /**
  * Extracts just the trip index from a trip ID without full decoding.
- * @param tripBoardingId - The encoded trip boarding ID
+ * @param tripStopId - The encoded trip boarding ID
  * @returns The trip index
  */
-export const getTripIndex = (
-  tripBoardingId: TripBoardingId,
-): TripRouteIndex => {
-  return Number((tripBoardingId >> TRIP_INDEX_SHIFT) & VALUE_MASK);
+export const getTripIndex = (tripStopId: TripStopId): TripRouteIndex => {
+  return Number((tripStopId >> TRIP_INDEX_SHIFT) & VALUE_MASK);
 };


### PR DESCRIPTION
Parses GTFS type 1 guaranteed transfers (trip-to-trip only). Adjust the router to take guaranteed trip transfers into account during routing. Ensures that the default 2 minutes transfer time is applied in all cases.

BREAKING CHANGE: Timetable binary format updated and is not compatible with the previous one.

Fixes https://github.com/aubryio/minotor/issues/33 and https://github.com/aubryio/minotor/issues/36
